### PR TITLE
[codex] Fix macOS connector signing runtime

### DIFF
--- a/connector/pyproject.toml
+++ b/connector/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "claude-agent-sdk",
-    "httpx>=0.28.1",
+    "httpx[socks]>=0.28.1",
     "loguru>=0.7.3",
     "pexpect>=4.9.0; sys_platform != 'win32'",
     "ptyprocess>=0.7.0; sys_platform != 'win32'",

--- a/desktop-next/build/entitlements.mac.plist
+++ b/desktop-next/build/entitlements.mac.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop-next/electron/main.cjs
+++ b/desktop-next/electron/main.cjs
@@ -163,7 +163,7 @@ function ensureConnectorRuntimeDirs() {
   fs.mkdirSync(connectorRuntimeDir(), { recursive: true });
   fs.mkdirSync(connectorUvCacheDir(), { recursive: true });
   if (!fs.existsSync(path.join(bundledConnectorDir(), "pyproject.toml"))) return;
-  if (fs.existsSync(path.join(connectorRuntimeProjectDir(), "pyproject.toml"))) return;
+  fs.rmSync(connectorRuntimeProjectDir(), { recursive: true, force: true });
   fs.cpSync(bundledConnectorDir(), connectorRuntimeProjectDir(), {
     recursive: true,
     filter(source) {

--- a/desktop-next/electron/main.cjs
+++ b/desktop-next/electron/main.cjs
@@ -134,6 +134,45 @@ function defaultConnectorStateDbPath() {
   return path.join(path.dirname(configPath), "connector-state.sqlite3");
 }
 
+function connectorRuntimeDir() {
+  return userDataPath("connector-runtime");
+}
+
+function bundledConnectorDir() {
+  return path.join(process.resourcesPath, "connector");
+}
+
+function connectorRuntimeProjectDir() {
+  return path.join(connectorRuntimeDir(), "connector");
+}
+
+function connectorUvEnvironmentPath() {
+  return path.join(connectorRuntimeDir(), ".venv");
+}
+
+function connectorUvCacheDir() {
+  return userDataPath("uv-cache");
+}
+
+function connectorWorkingDir() {
+  return app.isPackaged ? connectorRuntimeDir() : state.connectorDir;
+}
+
+function ensureConnectorRuntimeDirs() {
+  if (!app.isPackaged) return;
+  fs.mkdirSync(connectorRuntimeDir(), { recursive: true });
+  fs.mkdirSync(connectorUvCacheDir(), { recursive: true });
+  if (!fs.existsSync(path.join(bundledConnectorDir(), "pyproject.toml"))) return;
+  if (fs.existsSync(path.join(connectorRuntimeProjectDir(), "pyproject.toml"))) return;
+  fs.cpSync(bundledConnectorDir(), connectorRuntimeProjectDir(), {
+    recursive: true,
+    filter(source) {
+      const name = path.basename(source);
+      return name !== ".venv" && name !== "__pycache__" && !source.endsWith(".pyc");
+    },
+  });
+}
+
 function readJson(filePath, fallback) {
   try {
     return JSON.parse(fs.readFileSync(filePath, "utf8"));
@@ -333,6 +372,12 @@ function connectorEnv() {
     PYTHONUNBUFFERED: "1",
     FORCE_COLOR: "0",
   };
+  if (app.isPackaged) {
+    Object.assign(env, {
+      UV_PROJECT_ENVIRONMENT: connectorUvEnvironmentPath(),
+      UV_CACHE_DIR: connectorUvCacheDir(),
+    });
+  }
   const pypiIndexUrl = typeof state.uvPypiIndexUrl === "string" ? state.uvPypiIndexUrl.trim() : "";
   if (pypiIndexUrl) {
     env.UV_INDEX_URL = pypiIndexUrl;
@@ -435,7 +480,7 @@ function normalizeShellEnvironment(value) {
 }
 
 function resolveConnectorDir() {
-  if (app.isPackaged) return path.join(process.resourcesPath, "connector");
+  if (app.isPackaged) return connectorRuntimeProjectDir();
   return path.resolve(__dirname, "..", "..", "connector");
 }
 
@@ -826,6 +871,7 @@ function waitForMainWindowReady() {
 function startRpcProcess(options = {}) {
   if (rpcProcess) return;
   const requiresConfig = options.requiresConfig !== false;
+  ensureConnectorRuntimeDirs();
   const setupIssue = refreshLocalSetupState();
   if (setupIssue && (requiresConfig || setupIssue !== "configMissing")) {
     mergeConnectorState({
@@ -853,7 +899,7 @@ function startRpcProcess(options = {}) {
     return;
   }
   rpcProcess = spawn(uvPath, args, {
-    cwd: state.connectorDir,
+    cwd: connectorWorkingDir(),
     env: connectorEnv(),
     detached: process.platform !== "win32",
     windowsHide: true,
@@ -1130,6 +1176,7 @@ app.whenReady().then(async () => {
   state.settingsPath = userDataPath("desktop-settings.json");
   state.logPath = userDataPath("logs");
   state.connectorDir = resolveConnectorDir();
+  ensureConnectorRuntimeDirs();
   loadDesktopSettings();
   shellEnvironment = await readShellEnvironment();
   initLogSeq();

--- a/desktop-next/package.json
+++ b/desktop-next/package.json
@@ -120,8 +120,9 @@
     },
     "mac": {
       "icon": "build/icon.icns",
-      "identity": "-",
-      "hardenedRuntime": false,
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "gatekeeperAssess": false,
       "target": "dmg"
     },

--- a/desktop-next/scripts/macos-release-config-contract.test.mjs
+++ b/desktop-next/scripts/macos-release-config-contract.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectDir = join(scriptDir, "..");
+
+const packageJson = JSON.parse(readFileSync(join(projectDir, "package.json"), "utf8"));
+const mac = packageJson.build?.mac ?? {};
+
+assert.equal(mac.hardenedRuntime, true, "macOS release builds must enable hardenedRuntime");
+assert.notEqual(mac.identity, "-", "macOS release builds must not force ad-hoc signing");
+assert.equal(mac.entitlements, "build/entitlements.mac.plist");
+assert.equal(mac.entitlementsInherit, "build/entitlements.mac.plist");
+
+const entitlements = readFileSync(join(projectDir, "build/entitlements.mac.plist"), "utf8");
+
+for (const key of [
+  "com.apple.security.cs.allow-jit",
+  "com.apple.security.cs.allow-unsigned-executable-memory",
+  "com.apple.security.cs.disable-library-validation",
+]) {
+  assert.match(entitlements, new RegExp(`<key>${key}</key>\\s*<true/>`), `missing ${key}`);
+}
+
+const mainSource = readFileSync(join(projectDir, "electron/main.cjs"), "utf8");
+
+assert.match(mainSource, /function connectorRuntimeDir\(\)[\s\S]*userDataPath\("connector-runtime"\)/, "packaged connector runtime cwd must be under userData");
+assert.match(mainSource, /function bundledConnectorDir\(\)[\s\S]*process\.resourcesPath,\s*"connector"/, "packaged connector source must be read from resources");
+assert.match(mainSource, /function connectorRuntimeProjectDir\(\)[\s\S]*path\.join\(connectorRuntimeDir\(\),\s*"connector"\)/, "packaged connector project must live under userData");
+assert.match(mainSource, /function connectorWorkingDir\(\)[\s\S]*app\.isPackaged \? connectorRuntimeDir\(\) : state\.connectorDir/, "packaged connector cwd must use userData while dev keeps source cwd");
+assert.match(mainSource, /function resolveConnectorDir\(\)[\s\S]*if \(app\.isPackaged\) return connectorRuntimeProjectDir\(\)/, "packaged connector project must not point into the signed app bundle");
+assert.match(mainSource, /fs\.cpSync\(bundledConnectorDir\(\), connectorRuntimeProjectDir\(\)/, "packaged connector source must be copied to a writable runtime project");
+assert.match(mainSource, /UV_PROJECT_ENVIRONMENT:\s*connectorUvEnvironmentPath\(\)/, "uv virtualenv must be outside the signed app bundle");
+assert.match(mainSource, /UV_CACHE_DIR:\s*connectorUvCacheDir\(\)/, "uv cache must be outside the signed app bundle");
+assert.match(mainSource, /cwd:\s*connectorWorkingDir\(\)/, "connector RPC cwd must not be the bundled resource directory");
+assert.doesNotMatch(mainSource, /cwd:\s*state\.connectorDir/, "connector RPC must not use the signed connector resource as cwd");
+assert.doesNotMatch(mainSource, /"--locked"/, "packaged uv run must not require a lockfile that is not bundled");
+
+console.log("macos release signing config ok");

--- a/desktop-next/scripts/macos-release-config-contract.test.mjs
+++ b/desktop-next/scripts/macos-release-config-contract.test.mjs
@@ -31,6 +31,7 @@ assert.match(mainSource, /function bundledConnectorDir\(\)[\s\S]*process\.resour
 assert.match(mainSource, /function connectorRuntimeProjectDir\(\)[\s\S]*path\.join\(connectorRuntimeDir\(\),\s*"connector"\)/, "packaged connector project must live under userData");
 assert.match(mainSource, /function connectorWorkingDir\(\)[\s\S]*app\.isPackaged \? connectorRuntimeDir\(\) : state\.connectorDir/, "packaged connector cwd must use userData while dev keeps source cwd");
 assert.match(mainSource, /function resolveConnectorDir\(\)[\s\S]*if \(app\.isPackaged\) return connectorRuntimeProjectDir\(\)/, "packaged connector project must not point into the signed app bundle");
+assert.match(mainSource, /fs\.rmSync\(connectorRuntimeProjectDir\(\), \{ recursive: true, force: true \}\)/, "packaged connector runtime project must refresh stale bundled dependencies");
 assert.match(mainSource, /fs\.cpSync\(bundledConnectorDir\(\), connectorRuntimeProjectDir\(\)/, "packaged connector source must be copied to a writable runtime project");
 assert.match(mainSource, /UV_PROJECT_ENVIRONMENT:\s*connectorUvEnvironmentPath\(\)/, "uv virtualenv must be outside the signed app bundle");
 assert.match(mainSource, /UV_CACHE_DIR:\s*connectorUvCacheDir\(\)/, "uv cache must be outside the signed app bundle");


### PR DESCRIPTION
## Summary

- enable proper macOS hardened-runtime entitlements for Electron/V8
- move packaged connector runtime writes out of the signed `.app` bundle
- refresh the packaged connector runtime project on app startup so stale userData copies pick up new dependencies
- add `httpx[socks]` so SOCKS proxy environments include `socksio`
- add a macOS release config contract test to guard the signing/runtime assumptions

## Root Cause

The macOS app was signed with Hardened Runtime but without the Electron/V8 JIT entitlements, causing V8 to fail reserving its CodeRange at startup. After that was fixed, the packaged connector still used the signed resources directory as its uv project, so uv attempted to write `.venv` and `uv.lock` into the sealed app bundle or read-only DMG.

The SOCKS proxy error came from `httpx` being installed without its `socks` extra; `python-socks` alone does not satisfy httpx's `socksio` dependency path. Existing installations could also keep using a stale copied connector project under userData, so the app now refreshes the packaged connector project on startup while preserving sibling runtime state such as `.venv` and `uv-cache`.

## Validation

- `npm exec --yes --package=node@22 -- node scripts/macos-release-config-contract.test.mjs`
- `uv run python -c 'import httpx, socksio'` from `connector/`
- rebuilt macOS arm64 DMG from branch `codex/fix-macos-connector-runtime-signing-socks` without merging to `main`
- packaged app contains `connector/pyproject.toml` with `httpx[socks]>=0.28.1`
- packaged app contains the startup runtime refresh guard in `electron/main.cjs`
- stale runtime simulation refreshed an old userData `connector-runtime/connector/pyproject.toml` to the packaged `httpx[socks]` version while preserving `.venv` and `uv-cache`
- app notarization accepted: `b5f185b6-2e12-4fad-8aa0-a8e3b030500a`
- final DMG notarization accepted: `08a1bc64-8c47-4857-8e19-7157f2b48e27`
- `stapler validate`, `spctl`, DMG `codesign --verify`, mounted-app `spctl`, mounted-app `codesign --verify --deep --strict`
- mounted final DMG structure verified: root contains `Agents Anywhere Connector Next.app/Contents` directly, not a nested `.app` wrapper

## Final Artifact

`/Users/apple/aa-builds/agents-anywhere-main-dmg-20260706-065311/desktop-next/release/Agents Anywhere Connector Next-0.1.7-arm64.dmg`

SHA-256:

`8e39bc782dcf6172feeec7a4a2c2aefff4dccd0d10500c3aa2ade81b1fdd70b3`
