### PR TITLE
[codex] Fix web-next page bugs

### DIFF
--- a/web-next/messages/en.json
+++ b/web-next/messages/en.json
@@ -656,7 +656,7 @@
       "createDevice": "Create device",
       "methodTitle": "Choose pairing method",
       "methodDescription": "How would you like to connect {name} to this instance?",
-      "desktopTitle": "Use desktop connector",
+      "desktopTitle": "Use desktop connector (Recommended)",
       "desktopDescription": "Use the desktop app to pair this computer or another device.",
       "desktopMethodTitle": "Choose a desktop connector method",
       "desktopMethodDescription": "How would you like to use the desktop connector for {name}?",

--- a/web-next/messages/en.json
+++ b/web-next/messages/en.json
@@ -422,6 +422,8 @@
       "addAgentFailed": "Failed to add agent",
       "addAgentNotFound": "Agent not found on this device.",
       "addAgentSuccess": "{name} was added.",
+      "allAgentsAddedTitle": "All agents added",
+      "allAgentsAddedDescription": "All supported agents on this device have already been added.",
       "agentIssue": "Issue",
       "configureAgent": "Configure {name}",
       "removeAgent": "Remove {name}",

--- a/web-next/messages/zh-CN.json
+++ b/web-next/messages/zh-CN.json
@@ -422,6 +422,8 @@
       "addAgentFailed": "无法添加 Agent",
       "addAgentNotFound": "这台设备上没有找到 Agent。",
       "addAgentSuccess": "已添加 {name}。",
+      "allAgentsAddedTitle": "所有 Agents 已添加",
+      "allAgentsAddedDescription": "本机所有支持的 Agents 都已添加。",
       "agentIssue": "异常",
       "configureAgent": "配置 {name}",
       "removeAgent": "移除 {name}",

--- a/web-next/messages/zh-CN.json
+++ b/web-next/messages/zh-CN.json
@@ -656,7 +656,7 @@
       "createDevice": "创建设备",
       "methodTitle": "选择配对方式",
       "methodDescription": "你想如何把 {name} 连接到这个实例？",
-      "desktopTitle": "使用桌面连接器",
+      "desktopTitle": "使用桌面连接器（推荐）",
       "desktopDescription": "使用桌面应用完成本机或其他设备的配对。",
       "desktopMethodTitle": "选择桌面连接器方式",
       "desktopMethodDescription": "你想如何使用桌面连接器连接 {name}？",

--- a/web-next/src/components/app-sidebar.tsx
+++ b/web-next/src/components/app-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Search, Plus, Settings, Users, Server, LogOut, Pin, Archive, CheckCheck, Copy, FolderOpen } from "lucide-react"
+import { Search, Plus, Settings, Users, Server, LogOut, Pin, Archive, CheckCheck, Copy, FolderOpen, Pencil } from "lucide-react"
 import { toast } from "sonner"
 import { PairDeviceDialog } from "@/components/pair-device-dialog"
 
@@ -334,17 +334,18 @@ function SessionSidebarItem({
 }) {
   const t = useTranslations("dashboard")
   const tSession = useTranslations("dashboard.session")
-  const [editingTitle, setEditingTitle] = React.useState(false)
+  const tCommon = useTranslations("common")
+  const [renameOpen, setRenameOpen] = React.useState(false)
   const [titleDraft, setTitleDraft] = React.useState(item.title ?? "")
   const [renaming, setRenaming] = React.useState(false)
 
   React.useEffect(() => {
-    if (!editingTitle) setTitleDraft(item.title ?? "")
-  }, [editingTitle, item.title])
+    if (!renameOpen) setTitleDraft(item.title ?? "")
+  }, [item.title, renameOpen])
 
   const cancelRename = React.useCallback(() => {
     setTitleDraft(item.title ?? "")
-    setEditingTitle(false)
+    setRenameOpen(false)
   }, [item.title])
 
   const submitRename = React.useCallback(async () => {
@@ -355,13 +356,13 @@ function SessionSidebarItem({
     }
     if (renaming) return
     if (nextTitle === item.title) {
-      setEditingTitle(false)
+      setRenameOpen(false)
       return
     }
     setRenaming(true)
     try {
       const ok = await onRename(nextTitle)
-      if (ok) setEditingTitle(false)
+      if (ok) setRenameOpen(false)
       else toast.error(tSession("renameFailed"))
     } finally {
       setRenaming(false)
@@ -378,46 +379,9 @@ function SessionSidebarItem({
   }
 
   return (
-    <ContextMenu>
-      <SidebarMenuItem className="group/session">
-        {editingTitle ? (
-          <div className="flex h-8 items-center gap-2 rounded-xl px-2">
-            <span
-              className={cn(
-                "size-1.5 shrink-0 rounded-full border",
-                item.unread
-                  ? "border-primary bg-primary"
-                  : item.status === "running"
-                  ? "border-emerald-500 bg-emerald-500"
-                  : item.status === "error"
-                    ? "border-red-500/70"
-                    : item.status === "waiting_approval"
-                      ? "border-amber-400/70"
-                      : "border-muted-foreground/50",
-              )}
-            />
-            <Input
-              autoFocus
-              value={titleDraft}
-              onChange={(event) => setTitleDraft(event.currentTarget.value)}
-              onBlur={cancelRename}
-              onKeyDown={(event) => {
-                if (event.nativeEvent.isComposing) return
-                if (event.key === "Enter") {
-                  event.preventDefault()
-                  void submitRename()
-                }
-                if (event.key === "Escape") {
-                  event.preventDefault()
-                  cancelRename()
-                }
-              }}
-              disabled={renaming}
-              aria-label={tSession("renameTitle")}
-              className="h-7 min-w-0 flex-1 rounded-lg text-xs"
-            />
-          </div>
-        ) : (
+    <>
+      <ContextMenu>
+        <SidebarMenuItem className="group/session">
           <ContextMenuTrigger asChild>
             <div>
               <SidebarMenuButton
@@ -447,9 +411,7 @@ function SessionSidebarItem({
               </SidebarMenuButton>
             </div>
           </ContextMenuTrigger>
-        )}
 
-        {!editingTitle ? (
           <div
             className={cn(
               "absolute right-1 top-1/2 hidden -translate-y-1/2 items-center gap-0.5",
@@ -483,31 +445,77 @@ function SessionSidebarItem({
             <Archive className="size-3" />
           </button>
           </div>
-        ) : null}
-      </SidebarMenuItem>
-      <ContextMenuContent className="w-52">
-        <ContextMenuItem onSelect={onOpen}>
-          <FolderOpen className="size-4" />
-          {t("actions.open")}
-        </ContextMenuItem>
-        <ContextMenuItem onSelect={() => setEditingTitle(true)}>
-          {t("actions.rename")}
-        </ContextMenuItem>
-        <ContextMenuItem onSelect={onTogglePin}>
-          <Pin className="size-4" />
-          {item.pinned ? t("actions.unpin") : t("actions.pin")}
-        </ContextMenuItem>
-        <ContextMenuItem onSelect={onToggleArchive}>
-          <Archive className="size-4" />
-          {item.archived ? t("actions.unarchive") : t("actions.archive")}
-        </ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem onSelect={() => void copySessionId()}>
-          <Copy className="size-4" />
-          {t("actions.copySessionId")}
-        </ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
+        </SidebarMenuItem>
+        <ContextMenuContent className="w-52">
+          <ContextMenuItem onSelect={onOpen}>
+            <FolderOpen className="size-4" />
+            {t("actions.open")}
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => setRenameOpen(true)}>
+            <Pencil className="size-4" />
+            {t("actions.rename")}
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={onTogglePin}>
+            <Pin className="size-4" />
+            {item.pinned ? t("actions.unpin") : t("actions.pin")}
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={onToggleArchive}>
+            <Archive className="size-4" />
+            {item.archived ? t("actions.unarchive") : t("actions.archive")}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem onSelect={() => void copySessionId()}>
+            <Copy className="size-4" />
+            {t("actions.copySessionId")}
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <Dialog open={renameOpen} onOpenChange={(open) => {
+        if (open) {
+          setTitleDraft(item.title ?? "")
+          setRenameOpen(true)
+        } else {
+          cancelRename()
+        }
+      }}>
+        <DialogContent className="sm:max-w-sm">
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault()
+              void submitRename()
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>{tSession("renameTitle")}</DialogTitle>
+            </DialogHeader>
+            <Input
+              autoFocus
+              value={titleDraft}
+              onChange={(event) => setTitleDraft(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) return
+                if (event.key === "Escape") {
+                  event.preventDefault()
+                  cancelRename()
+                }
+              }}
+              disabled={renaming}
+              aria-label={tSession("renameTitle")}
+            />
+            <DialogFooter className="gap-2 sm:gap-2">
+              <Button type="button" variant="outline" onClick={cancelRename} disabled={renaming}>
+                {tCommon("cancel")}
+              </Button>
+              <Button type="submit" disabled={renaming || titleDraft.trim().length === 0}>
+                {tCommon("save")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 

--- a/web-next/src/components/pages/device-page.tsx
+++ b/web-next/src/components/pages/device-page.tsx
@@ -572,6 +572,13 @@ function agentsFromConnector(connector: DeviceConnector | null): AgentRow[] {
     .sort((a, b) => a.runtime.localeCompare(b.runtime))
 }
 
+function allSupportedAgentsHealthy(connector: DeviceConnector) {
+  return ADD_AGENT_RUNTIME_OPTIONS.every(({ id }) => {
+    const agent = connector.runtimeCapabilities.attached[id]
+    return agent ? reportIsHealthy(agent) : false
+  })
+}
+
 function reportIsHealthy(agent: AttachedAgent) {
   if (agent.report.error) return false
   if (!agent.report.selected) return false
@@ -613,6 +620,7 @@ export function DevicePage() {
   const [sessionTab, setSessionTab] = React.useState<SessionTabId>("active")
   const [configAgent, setConfigAgent] = React.useState<AgentRow | null>(null)
   const [addAgentOpen, setAddAgentOpen] = React.useState(false)
+  const [allAgentsAddedOpen, setAllAgentsAddedOpen] = React.useState(false)
   const [addingAgent, setAddingAgent] = React.useState(false)
   const [agentSettings, setAgentSettings] = React.useState<Record<string, RuntimeSettingsResponse | null>>({})
   const [agentSchemas, setAgentSchemas] = React.useState<Record<string, RuntimeConfigSchema | null>>({})
@@ -648,6 +656,7 @@ export function DevicePage() {
       setAgentSettingsError({})
       setConfigAgent(null)
       setAddAgentOpen(false)
+      setAllAgentsAddedOpen(false)
       setAddingAgent(false)
       setRemoveAgentRuntime(null)
       setSelectMode(false)
@@ -805,6 +814,14 @@ export function DevicePage() {
     } finally {
       setAddingAgent(false)
     }
+  }
+
+  const handleAddAgentClick = () => {
+    if (allSupportedAgentsHealthy(connector)) {
+      setAllAgentsAddedOpen(true)
+      return
+    }
+    setAddAgentOpen(true)
   }
 
   const removeAgent = async () => {
@@ -970,7 +987,7 @@ export function DevicePage() {
               type="button"
               variant="outline"
               size="sm"
-              onClick={() => setAddAgentOpen(true)}
+              onClick={handleAddAgentClick}
               disabled={connector.status !== "online"}
             >
               <Plus />
@@ -1205,6 +1222,20 @@ export function DevicePage() {
         adding={addingAgent}
         onAdd={addAgent}
       />
+
+      <Dialog open={allAgentsAddedOpen} onOpenChange={setAllAgentsAddedOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("allAgentsAddedTitle")}</DialogTitle>
+            <DialogDescription>{t("allAgentsAddedDescription")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={() => setAllAgentsAddedOpen(false)}>
+              {tCommon("close")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <PairDeviceDialog
         open={setupOpen}

--- a/web-next/src/components/pages/device-workspace-page.tsx
+++ b/web-next/src/components/pages/device-workspace-page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronLeft, FolderOpen, Plus } from "lucide-react"
+import { ChevronLeft, FolderOpen } from "lucide-react"
 import type { Layout } from "react-resizable-panels"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -192,13 +192,6 @@ export function DeviceWorkspacePage() {
                 {t("sessionCount", { count: sessions.length })}
               </p>
             </div>
-            <button
-              type="button"
-              className="rounded p-1 text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground"
-              aria-label={t("addWorkspace")}
-            >
-              <Plus className="size-3.5" />
-            </button>
           </div>
 
           {/* List */}

--- a/web-next/src/components/pair-device-dialog.tsx
+++ b/web-next/src/components/pair-device-dialog.tsx
@@ -478,18 +478,6 @@ export function PairDeviceDialog({ open, onOpenChange, onConnectorCreated, setup
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={handleSelectCommand}
-                  className="h-auto w-full min-w-0 flex-col items-start gap-0.5 whitespace-normal px-4 py-3 text-left"
-                >
-                  <span className="flex min-w-0 items-center gap-2 font-medium">
-                    <Terminal className="size-4" />
-                    {t("commandTitle")}
-                  </span>
-                  <span className="min-w-0 break-words text-sm text-muted-foreground">{t("commandDescription")}</span>
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
                   onClick={handleSelectDesktop}
                   className="h-auto w-full min-w-0 flex-col items-start gap-0.5 whitespace-normal px-4 py-3 text-left"
                 >
@@ -498,6 +486,18 @@ export function PairDeviceDialog({ open, onOpenChange, onConnectorCreated, setup
                     {t("desktopTitle")}
                   </span>
                   <span className="min-w-0 break-words text-sm text-muted-foreground">{t("desktopDescription")}</span>
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleSelectCommand}
+                  className="h-auto w-full min-w-0 flex-col items-start gap-0.5 whitespace-normal px-4 py-3 text-left"
+                >
+                  <span className="flex min-w-0 items-center gap-2 font-medium">
+                    <Terminal className="size-4" />
+                    {t("commandTitle")}
+                  </span>
+                  <span className="min-w-0 break-words text-sm text-muted-foreground">{t("commandDescription")}</span>
                 </Button>
               </div>
             </>

--- a/web-next/src/components/panels/runtime-icons.tsx
+++ b/web-next/src/components/panels/runtime-icons.tsx
@@ -1,5 +1,46 @@
 import * as React from "react"
 
+function PanelStrokeIcon({
+  className = "size-4",
+  children,
+  ...props
+}: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function PanelTerminalIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <PanelStrokeIcon {...props}>
+      <path d="m4 7 4 5-4 5" />
+      <path d="M12 19h8" />
+    </PanelStrokeIcon>
+  )
+}
+
+export function PanelFilesIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <PanelStrokeIcon {...props}>
+      <path d="M14 2H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V8z" />
+      <path d="M14 2v6h6" />
+      <path d="M4 6v14a2 2 0 0 0 2 2h11" />
+    </PanelStrokeIcon>
+  )
+}
+
 export function ChevronExternal({ className = "size-3.5", ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/web-next/src/components/panels/runtime-icons.tsx
+++ b/web-next/src/components/panels/runtime-icons.tsx
@@ -1,46 +1,5 @@
 import * as React from "react"
 
-function PanelStrokeIcon({
-  className = "size-4",
-  children,
-  ...props
-}: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-      {...props}
-    >
-      {children}
-    </svg>
-  )
-}
-
-export function PanelTerminalIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <PanelStrokeIcon {...props}>
-      <path d="m4 7 4 5-4 5" />
-      <path d="M12 19h8" />
-    </PanelStrokeIcon>
-  )
-}
-
-export function PanelFilesIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <PanelStrokeIcon {...props}>
-      <path d="M14 2H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V8z" />
-      <path d="M14 2v6h6" />
-      <path d="M4 6v14a2 2 0 0 0 2 2h11" />
-    </PanelStrokeIcon>
-  )
-}
-
 export function ChevronExternal({ className = "size-3.5", ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/web-next/src/components/session-detail.tsx
+++ b/web-next/src/components/session-detail.tsx
@@ -184,18 +184,27 @@ function buildOptimisticUserMessage({
   sessionId,
   clientMessageId,
   text,
+  attachments,
   items,
   nextSeq,
 }: {
   sessionId: string
   clientMessageId: string
   text: string
+  attachments: AttachedFile[]
   items: TimelineItem[]
   nextSeq: number
 }): TimelineItem {
   const now = new Date().toISOString()
   const lastOrderSeq = items.reduce((max, item) => Math.max(max, item.orderSeq), 0)
   const orderSeq = Math.max(lastOrderSeq + 1, nextSeq + 1)
+  const optimisticAttachments = attachments.map((attachment) => ({
+    fileId: `optimistic:${attachment.id}`,
+    name: attachment.name,
+    size: attachment.size,
+    mediaType: attachment.file.type,
+    optimistic: true,
+  }))
   return {
     id: `${OPTIMISTIC_ITEM_PREFIX}${clientMessageId}`,
     sessionId,
@@ -203,7 +212,7 @@ function buildOptimisticUserMessage({
     type: "message",
     status: "pending",
     role: "user",
-    content: { text },
+    content: optimisticAttachments.length > 0 ? { text, attachments: optimisticAttachments } : { text },
     source: { clientMessageId, optimistic: true },
     orderSeq,
     revision: 0,
@@ -530,6 +539,7 @@ export function SessionDetail({
             sessionId: session.id,
             clientMessageId,
             text: messageText,
+            attachments,
             items: current.items,
             nextSeq: current.nextSeq,
           }),

--- a/web-next/src/components/session-view-header.tsx
+++ b/web-next/src/components/session-view-header.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Download, Loader2, PanelLeft } from "lucide-react"
+import { Download, FolderOpen, Loader2, PanelLeft, SquareTerminal } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -15,13 +15,12 @@ import type { SessionMemorySnapshot } from "@/components/session-detail"
 import { cn } from "@/lib/utils"
 import { useTranslations } from "next-intl"
 import type { SessionView as SessionViewModel } from "@/lib/demo-api"
-import { PanelFilesIcon, PanelTerminalIcon } from "@/components/panels/runtime-icons"
 
 type PanelIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>
 
 const PANEL_META: Record<PanelId, { titleKey: "panelFiles" | "panelShell"; icon: PanelIcon }> = {
-  files: { titleKey: "panelFiles", icon: PanelFilesIcon },
-  terminal: { titleKey: "panelShell", icon: PanelTerminalIcon },
+  files: { titleKey: "panelFiles", icon: FolderOpen },
+  terminal: { titleKey: "panelShell", icon: SquareTerminal },
 }
 
 const HEADER_BLUR_LAYERS = buildBlurGradientLayers({

--- a/web-next/src/components/session-view-header.tsx
+++ b/web-next/src/components/session-view-header.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Download, FolderTree, Loader2, PanelLeft, SquareTerminal } from "lucide-react"
+import { Download, Loader2, PanelLeft } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -15,10 +15,13 @@ import type { SessionMemorySnapshot } from "@/components/session-detail"
 import { cn } from "@/lib/utils"
 import { useTranslations } from "next-intl"
 import type { SessionView as SessionViewModel } from "@/lib/demo-api"
+import { PanelFilesIcon, PanelTerminalIcon } from "@/components/panels/runtime-icons"
 
-const PANEL_META: Record<PanelId, { titleKey: "panelFiles" | "panelShell"; icon: typeof FolderTree }> = {
-  files: { titleKey: "panelFiles", icon: FolderTree },
-  terminal: { titleKey: "panelShell", icon: SquareTerminal },
+type PanelIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>
+
+const PANEL_META: Record<PanelId, { titleKey: "panelFiles" | "panelShell"; icon: PanelIcon }> = {
+  files: { titleKey: "panelFiles", icon: PanelFilesIcon },
+  terminal: { titleKey: "panelShell", icon: PanelTerminalIcon },
 }
 
 const HEADER_BLUR_LAYERS = buildBlurGradientLayers({
@@ -159,8 +162,8 @@ export function SessionViewHeader({
           exporting={exporting}
         />
         <div className="ml-auto flex items-center gap-1">
-          <TogglePanelButton id="files" icon={FolderTree} />
-          <TogglePanelButton id="terminal" icon={SquareTerminal} />
+          <TogglePanelButton id="files" icon={PANEL_META.files.icon} />
+          <TogglePanelButton id="terminal" icon={PANEL_META.terminal.icon} />
         </div>
       </div>
     </header>
@@ -296,7 +299,7 @@ function SessionMetaBadge({
   )
 }
 
-function TogglePanelButton({ id, icon: Icon }: { id: PanelId; icon: typeof FolderTree }) {
+function TogglePanelButton({ id, icon: Icon }: { id: PanelId; icon: PanelIcon }) {
   const { panels, setPanelMode } = useWorkspace()
   const t = useTranslations("dashboard.session")
   const active = panels[id] !== "closed"

--- a/web-next/src/components/session/message-attachments.tsx
+++ b/web-next/src/components/session/message-attachments.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Download, ExternalLink, FileText } from "lucide-react"
+import { Download, ExternalLink, FileText, Loader2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
@@ -53,6 +53,9 @@ function MessageAttachmentItem({
   const openUrl = attachmentOpenUrl(sessionId, attachment.fileId, token)
   const isImage = isImageAttachment(attachment)
   const [previewOpen, setPreviewOpen] = useState(false)
+  if (attachment.optimistic) {
+    return <AttachmentFileCard attachment={attachment} name={name} mediaType={mediaType} align={align} pending />
+  }
   if (isImage) {
     return (
       <>
@@ -88,11 +91,40 @@ function MessageAttachmentItem({
   }
 
   return (
+    <AttachmentFileCard
+      attachment={attachment}
+      name={name}
+      mediaType={mediaType}
+      align={align}
+      openUrl={openUrl}
+    />
+  )
+}
+
+function AttachmentFileCard({
+  attachment,
+  name,
+  mediaType,
+  align,
+  openUrl,
+  pending = false,
+}: {
+  attachment: ReconcileAttachment
+  name: string
+  mediaType: string
+  align: "left" | "right"
+  openUrl?: string
+  pending?: boolean
+}) {
+  const details = [mediaType || "file", formatBytes(attachment.size)].filter(Boolean).join(" - ")
+
+  return (
     <div
       className={cn(
         "max-w-full overflow-hidden rounded-lg border border-border/80 bg-background/80 text-foreground shadow-sm",
         "w-[min(420px,100%)]",
         align === "right" && "bg-background/70",
+        pending && "opacity-80",
       )}
     >
       <div className="flex min-w-0 items-center gap-2 px-2.5 py-2">
@@ -100,19 +132,39 @@ function MessageAttachmentItem({
         <div className="min-w-0 flex-1">
           <div className="truncate text-xs font-medium">{name}</div>
           <div className="truncate text-[11px] text-muted-foreground">
-            {[mediaType || "file", formatBytes(attachment.size)].filter(Boolean).join(" - ")}
+            {pending ? (
+              <span className="inline-flex items-center gap-1">
+                <Loader2 className="size-3 animate-spin" />
+                <span>{[details, "Pending"].filter(Boolean).join(" - ")}</span>
+              </span>
+            ) : (
+              details
+            )}
           </div>
         </div>
-        <Button asChild variant="ghost" size="icon-sm" className="shrink-0">
-          <a href={openUrl} target="_blank" rel="noreferrer" aria-label={`Open ${name}`}>
-            <ExternalLink className="size-3.5" />
-          </a>
-        </Button>
-        <Button asChild variant="ghost" size="icon-sm" className="shrink-0">
-          <a href={openUrl} download={name} aria-label={`Download ${name}`}>
-            <Download className="size-3.5" />
-          </a>
-        </Button>
+        {pending ? (
+          <>
+            <Button variant="ghost" size="icon-sm" className="shrink-0" disabled aria-label={`Open ${name}`}>
+              <ExternalLink className="size-3.5" />
+            </Button>
+            <Button variant="ghost" size="icon-sm" className="shrink-0" disabled aria-label={`Download ${name}`}>
+              <Download className="size-3.5" />
+            </Button>
+          </>
+        ) : openUrl ? (
+          <>
+            <Button asChild variant="ghost" size="icon-sm" className="shrink-0">
+              <a href={openUrl} target="_blank" rel="noreferrer" aria-label={`Open ${name}`}>
+                <ExternalLink className="size-3.5" />
+              </a>
+            </Button>
+            <Button asChild variant="ghost" size="icon-sm" className="shrink-0">
+              <a href={openUrl} download={name} aria-label={`Download ${name}`}>
+                <Download className="size-3.5" />
+              </a>
+            </Button>
+          </>
+        ) : null}
       </div>
     </div>
   )

--- a/web-next/src/components/session/session-tool-cards.tsx
+++ b/web-next/src/components/session/session-tool-cards.tsx
@@ -209,7 +209,7 @@ function CodePanelFrame({
 
 function HighlightedCodeContent({ code, language, maxHeight }: { code: string; language: string; maxHeight: number }) {
   return (
-    <ScrollArea contentWide className="min-w-0" style={{ maxHeight }}>
+    <ScrollArea contentWide className="min-w-0" style={{ height: maxHeight, maxHeight }}>
       <pre className="code-mono min-w-full w-max px-3 py-2 text-xs leading-relaxed">
         <code className="code-mono whitespace-pre">{highlightCode(code, language)}</code>
       </pre>
@@ -225,7 +225,7 @@ export function JsonBlock({ value }: { value: unknown }) {
 function DiffPanel({ code, maxHeight }: { code: string; maxHeight: number }) {
   const rows = React.useMemo(() => buildDiffRows(code), [code])
   return (
-    <ScrollArea contentWide className="min-w-0" style={{ maxHeight }}>
+    <ScrollArea contentWide className="min-w-0" style={{ height: maxHeight, maxHeight }}>
       <div className="code-mono w-max min-w-full py-2 text-xs">
         {rows.map((row, index) => (
           <div

--- a/web-next/src/features/dashboard/attachments.ts
+++ b/web-next/src/features/dashboard/attachments.ts
@@ -3,6 +3,7 @@ export type ReconcileAttachment = {
   name?: string;
   size?: number;
   mediaType?: string;
+  optimistic?: boolean;
 };
 
 export function extractAttachments(
@@ -20,6 +21,7 @@ export function extractAttachments(
     if (typeof obj.name === "string") att.name = obj.name;
     if (typeof obj.size === "number") att.size = obj.size;
     if (typeof obj.mediaType === "string") att.mediaType = obj.mediaType;
+    if (obj.optimistic === true) att.optimistic = true;
     out.push(att);
   }
   return out;


### PR DESCRIPTION
## Summary

- Fix Add Agent behavior when all supported agents are already detected, showing a dismissible dialog instead of reopening manual setup.
- Remove the unused workspace header add button and align session/runtime panel icons.
- Improve session UX with attachment optimistic rendering, stable diff preview scrolling, and dialog-based sidebar session rename.
- Update pairing method order to recommend the desktop connector first.

## Validation

- Ran `cd web-next && yarn typecheck` after the implemented changes.

## Notes

- This is a draft PR for maintainer review. Do not merge until repository administrators approve.