### PR TITLE
Fix new session optimistic message refresh

### DIFF
--- a/web-next/src/components/session-detail.tsx
+++ b/web-next/src/components/session-detail.tsx
@@ -72,6 +72,8 @@ const SCROLL_TO_BOTTOM_PRUNE_CHECK_MS = 120
 const INITIAL_TIMELINE_LIMIT = 100
 const TIMELINE_PAGE_LIMIT = 100
 const LOAD_OLDER_SCROLL_THRESHOLD = 96
+const SESSION_REFRESH_RETRY_LIMIT = 3
+const SESSION_REFRESH_RETRY_DELAY_MS = 700
 const COMPOSER_DRAFT_STORAGE_PREFIX = "agents-anywhere.sessionComposerDraft.v1."
 const COMPOSER_BLUR_LAYERS = buildComposerBlurLayers({
   height: 144,
@@ -165,6 +167,12 @@ function writeComposerDraft(sessionId: string, value: string) {
   }
 }
 
+function hasRealTimelineItemForClientMessage(items: TimelineItem[], clientMessageId: string): boolean {
+  return items.some((item) =>
+    !isOptimisticTimelineItem(item) && timelineClientMessageId(item) === clientMessageId,
+  )
+}
+
 export function SessionDetail({
   token,
   sessionId,
@@ -183,6 +191,7 @@ export function SessionDetail({
     getOptimisticSessionState,
     isOptimisticSession,
     markOptimisticMessageFailed,
+    sessionRefreshRequest,
   } = useWorkspace()
   const [state, setState] = React.useState<SessionStateResponse | null>(null)
   const [loading, setLoading] = React.useState(true)
@@ -350,7 +359,41 @@ export function SessionDetail({
     setState((current) => current ? { ...next, items: preserveOptimisticItems(next.items, current.items) } : next)
     nextSeqRef.current = Math.max(nextSeqRef.current, next.nextSeq)
     onSessionUpdated?.(next.session)
+    return next
   }, [markAutoScrollIfNearBottom, onSessionUpdated, sessionId, token])
+
+  React.useEffect(() => {
+    if (!sessionRefreshRequest || sessionRefreshRequest.sessionId !== sessionId || isLocalOptimisticSession) return
+    let cancelled = false
+    let retryTimer: number | null = null
+
+    const run = async (attempt: number) => {
+      try {
+        const next = await refresh({ scrollToBottom: true })
+        if (cancelled) return
+        const clientMessageId = sessionRefreshRequest.clientMessageId
+        if (!clientMessageId || hasRealTimelineItemForClientMessage(next.items, clientMessageId)) return
+        if (attempt >= SESSION_REFRESH_RETRY_LIMIT) return
+        retryTimer = window.setTimeout(() => {
+          retryTimer = null
+          void run(attempt + 1)
+        }, SESSION_REFRESH_RETRY_DELAY_MS)
+      } catch {
+        if (cancelled || attempt >= SESSION_REFRESH_RETRY_LIMIT) return
+        retryTimer = window.setTimeout(() => {
+          retryTimer = null
+          void run(attempt + 1)
+        }, SESSION_REFRESH_RETRY_DELAY_MS)
+      }
+    }
+
+    void run(0)
+
+    return () => {
+      cancelled = true
+      if (retryTimer !== null) window.clearTimeout(retryTimer)
+    }
+  }, [isLocalOptimisticSession, refresh, sessionId, sessionRefreshRequest])
 
   const loadOlderTimeline = React.useCallback(async () => {
     if (loadingOlderRef.current || loadingOlder || !state?.hasMore) return

--- a/web-next/src/components/task-composer.tsx
+++ b/web-next/src/components/task-composer.tsx
@@ -111,6 +111,7 @@ export function TaskComposer() {
     connectors,
     markOptimisticMessageFailed,
     openSession,
+    requestSessionRefresh,
     upsertSession,
     refreshData,
   } = useWorkspace()
@@ -377,6 +378,7 @@ export function TaskComposer() {
     addOptimisticMessage({
       clientMessageId,
       sessionId: localSessionId,
+      localSessionId,
       session: optimisticSession,
       item: buildOptimisticUserMessage({
         sessionId: localSessionId,
@@ -432,6 +434,7 @@ export function TaskComposer() {
         },
       )
       upsertSession(takeover.session)
+      requestSessionRefresh(sessionId, clientMessageId)
       refreshData()
     } catch (err) {
       const message = err instanceof Error ? err.message : t("createFailed")

--- a/web-next/src/components/workspace-context.tsx
+++ b/web-next/src/components/workspace-context.tsx
@@ -53,6 +53,13 @@ export type OptimisticSessionMessage = {
   sessionId: string
   item: TimelineItem
   session?: RealSessionView
+  localSessionId?: string
+}
+
+export type SessionRefreshRequest = {
+  id: number
+  sessionId: string
+  clientMessageId?: string
 }
 
 // ─── Hash routing helpers ─────────────────────────────────────
@@ -196,6 +203,7 @@ type WorkspaceState = {
   pairDeviceDialogOpen: boolean
   composerInsertion: ComposerInsertion | null
   optimisticMessages: OptimisticSessionMessage[]
+  sessionRefreshRequest: SessionRefreshRequest | null
 
   // Actions
   openSession: (id: string) => void
@@ -223,6 +231,7 @@ type WorkspaceState = {
   getOptimisticSessionState: (sessionId: string) => SessionStateResponse | null
   isOptimisticSession: (sessionId: string) => boolean
   markOptimisticMessageFailed: (clientMessageId: string, message: string) => void
+  requestSessionRefresh: (sessionId: string, clientMessageId?: string) => void
   appendPathToComposer: (path: string) => boolean
   refreshData: () => void
 }
@@ -303,8 +312,11 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   const [pairDeviceDialogOpen, setPairDeviceDialogOpen] = React.useState(false)
   const [composerInsertion, setComposerInsertion] = React.useState<ComposerInsertion | null>(null)
   const [optimisticMessages, setOptimisticMessages] = React.useState<OptimisticSessionMessage[]>([])
+  const [sessionRefreshRequest, setSessionRefreshRequest] = React.useState<SessionRefreshRequest | null>(null)
   const firstDeviceWizardCheckedRef = React.useRef(false)
   const composerInsertionSeqRef = React.useRef(0)
+  const sessionRefreshRequestSeqRef = React.useRef(0)
+  const routeRef = React.useRef<ParsedRoute>({ page: "home" })
 
   // ── Fetch data from mock API ──────────────────────────────
   const initialLoadDoneRef = React.useRef(false)
@@ -394,14 +406,21 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   // ── Hash routing ──────────────────────────────────────────
   React.useEffect(() => {
     // Correct from hash immediately on mount, then keep in sync.
-    setRoute(parseHash(window.location.hash))
+    const initialRoute = parseHash(window.location.hash)
+    routeRef.current = initialRoute
+    setRoute(initialRoute)
     setRouteReady(true)
-    const handler = () => React.startTransition(() => setRoute(parseHash(window.location.hash)))
+    const handler = () => {
+      const nextRoute = parseHash(window.location.hash)
+      routeRef.current = nextRoute
+      React.startTransition(() => setRoute(nextRoute))
+    }
     window.addEventListener("hashchange", handler)
     return () => window.removeEventListener("hashchange", handler)
   }, [])
 
   const pushRoute = React.useCallback((r: ParsedRoute) => {
+    routeRef.current = r
     window.location.hash = buildHash(r)
     React.startTransition(() => setRoute(r))
   }, [])
@@ -628,10 +647,11 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       next[index] = mapped
       return next
     })
-    if (route.page === "session" && route.sessionId === localSessionId) {
+    const currentRoute = routeRef.current
+    if (currentRoute.page === "session" && currentRoute.sessionId === localSessionId) {
       pushRoute({ page: "session", sessionId: session.id })
     }
-  }, [pushRoute, route])
+  }, [pushRoute])
 
   const markOptimisticMessageFailed = React.useCallback((clientMessageId: string, message: string) => {
     setOptimisticMessages((prev) =>
@@ -681,8 +701,17 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   }, [optimisticMessages])
 
   const isOptimisticSession = React.useCallback((sessionId: string) => {
-    return optimisticMessages.some((message) => message.sessionId === sessionId && message.session?.id === sessionId)
+    return optimisticMessages.some((message) => message.localSessionId === sessionId && message.sessionId === sessionId)
   }, [optimisticMessages])
+
+  const requestSessionRefresh = React.useCallback((sessionId: string, clientMessageId?: string) => {
+    sessionRefreshRequestSeqRef.current += 1
+    setSessionRefreshRequest({
+      id: sessionRefreshRequestSeqRef.current,
+      sessionId,
+      clientMessageId,
+    })
+  }, [])
 
   const appendPathToComposer = React.useCallback((path: string) => {
     if (route.page !== "session" || !route.sessionId) return false
@@ -726,6 +755,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     pairDeviceDialogOpen,
     composerInsertion,
     optimisticMessages,
+    sessionRefreshRequest,
     openSession,
     goHome,
     navigate,
@@ -751,6 +781,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     getOptimisticSessionState,
     isOptimisticSession,
     markOptimisticMessageFailed,
+    requestSessionRefresh,
     appendPathToComposer,
     refreshData: fetchData,
   }


### PR DESCRIPTION
## Summary

Fixes optimistic rendering for user messages created from the new-session flow.

## Root cause

After a temporary optimistic session was bound to the real backend session id, the real session could still be classified as a local optimistic session. That caused `SessionDetail` to skip normal refresh/SSE loading, leaving the pending message stuck until another send triggered a refresh.

## Changes

- Track the original local temporary session id separately from the real session id.
- Only treat an unbound temporary session as a local optimistic session.
- Request a targeted session refresh after the new-session send succeeds.
- Retry short-lived timeline refreshes while waiting for the real item matching `clientMessageId`.

## Validation

- `cd web-next && yarn typecheck`
