### PR TITLE
fix(server): add GPT-5.6 Codex catalog

### DIFF
--- a/server/agent_server/core/runtime_config.py
+++ b/server/agent_server/core/runtime_config.py
@@ -20,6 +20,9 @@ RuntimeName = Annotated[
 
 _RUNTIME_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
+CODEX_DEFAULT_MODEL = "gpt-5.6-sol"
+CODEX_DEFAULT_EFFORT = "medium"
+
 
 class RuntimeConfigOption(BaseModel):
     value: str | bool
@@ -105,8 +108,8 @@ DEFAULT_RUNTIME_SETTINGS: dict[str, dict[str, Any]] = {
     },
     "codex": {
         "permissionMode": "ask",
-        "model": None,
-        "effort": None,
+        "model": CODEX_DEFAULT_MODEL,
+        "effort": CODEX_DEFAULT_EFFORT,
     },
     "gemini": {
         "permissionMode": None,
@@ -273,7 +276,7 @@ DEFAULT_RUNTIME_CONFIG_SCHEMAS: dict[str, RuntimeConfigSchema] = {
     ),
     "codex": RuntimeConfigSchema(
         runtime="codex",
-        schemaVersion=3,
+        schemaVersion=4,
         fields=[
             RuntimeConfigField(
                 key="permissionMode",
@@ -304,6 +307,9 @@ DEFAULT_RUNTIME_CONFIG_SCHEMAS: dict[str, RuntimeConfigSchema] = {
                 type="enum",
                 allowSessionOverride=True,
                 options=[
+                    RuntimeConfigOption(value="gpt-5.6-sol", label="GPT-5.6-Sol"),
+                    RuntimeConfigOption(value="gpt-5.6-terra", label="GPT-5.6-Terra"),
+                    RuntimeConfigOption(value="gpt-5.6-luna", label="GPT-5.6-Luna"),
                     RuntimeConfigOption(value="gpt-5.5", label="GPT-5.5"),
                     RuntimeConfigOption(value="gpt-5.4", label="GPT-5.4"),
                     RuntimeConfigOption(value="gpt-5.4-mini", label="GPT-5.4 Mini"),
@@ -321,6 +327,8 @@ DEFAULT_RUNTIME_CONFIG_SCHEMAS: dict[str, RuntimeConfigSchema] = {
                     RuntimeConfigOption(value="medium", label="Medium"),
                     RuntimeConfigOption(value="high", label="High"),
                     RuntimeConfigOption(value="xhigh", label="Extra high"),
+                    RuntimeConfigOption(value="max", label="Max"),
+                    RuntimeConfigOption(value="ultra", label="Ultra"),
                 ],
             ),
         ],
@@ -330,6 +338,11 @@ DEFAULT_RUNTIME_CONFIG_SCHEMAS: dict[str, RuntimeConfigSchema] = {
 CLAUDE_NO_EFFORT_MODEL = "claude-haiku-4-5"
 _CLAUDE_OPUS_48_47_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
 _CLAUDE_OPUS_46_SONNET_46_EFFORTS = frozenset({"low", "medium", "high", "max"})
+_CODEX_56_SOL_TERRA_EFFORTS = frozenset(
+    {"low", "medium", "high", "xhigh", "max", "ultra"}
+)
+_CODEX_56_LUNA_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
+_CODEX_LEGACY_EFFORTS = frozenset({"low", "medium", "high", "xhigh"})
 
 
 def runtime_schema_key(runtime: str) -> str:
@@ -586,6 +599,15 @@ def claude_efforts_for_model(model: Any) -> frozenset[str]:
     return _CLAUDE_OPUS_46_SONNET_46_EFFORTS
 
 
+def codex_efforts_for_model(model: Any) -> frozenset[str]:
+    key = model if isinstance(model, str) else ""
+    if key in {"gpt-5.6-sol", "gpt-5.6-terra"}:
+        return _CODEX_56_SOL_TERRA_EFFORTS
+    if key == "gpt-5.6-luna":
+        return _CODEX_56_LUNA_EFFORTS
+    return _CODEX_LEGACY_EFFORTS
+
+
 def _normalize_model_effort_from_schema(
     settings: dict[str, Any],
     *,
@@ -603,6 +625,15 @@ def _normalize_model_effort_from_schema(
     result = deepcopy(settings)
     model = result.get("model")
     effort = result.get("effort")
+    model_options = model_field.options or []
+    if schema.runtime == "codex" and isinstance(model, str) and model and not any(
+        option.value == model for option in model_options
+    ):
+        if "model" in explicit_keys:
+            raise ValueError(f"model has unsupported value: {model}")
+        if model_options:
+            model = model_options[0].value
+            result["model"] = model
     allowed = _schema_efforts_for_model(model_field, effort_field, model)
     if allowed is None:
         return None
@@ -614,8 +645,29 @@ def _normalize_model_effort_from_schema(
     if effort is not None and effort not in allowed:
         if "effort" in explicit_keys:
             raise ValueError(f"effort {effort} is not supported by {model}")
-        result["effort"] = None
+        result["effort"] = (
+            _first_schema_effort_for_model(model_field, model)
+            if schema.runtime == "codex"
+            else None
+        )
     return result
+
+
+def _first_schema_effort_for_model(
+    model_field: RuntimeConfigField,
+    model: Any,
+) -> str | None:
+    selected = next(
+        (
+            option
+            for option in model_field.options or []
+            if isinstance(model, str) and model and option.value == model
+        ),
+        None,
+    )
+    if selected is None or not selected.efforts:
+        return None
+    return str(selected.efforts[0].value)
 
 
 def _schema_efforts_for_model(
@@ -667,9 +719,12 @@ def _default_effort_options_for_model(
     model: Any,
     effort_options: list[RuntimeConfigOption],
 ) -> list[RuntimeConfigOption]:
-    if runtime != "claude":
+    if runtime == "claude":
+        allowed = claude_efforts_for_model(model)
+    elif runtime == "codex":
+        allowed = codex_efforts_for_model(model)
+    else:
         return deepcopy(effort_options)
-    allowed = claude_efforts_for_model(model)
     return [deepcopy(option) for option in effort_options if str(option.value) in allowed]
 
 

--- a/server/agent_server/infra/repositories/agent_catalog.py
+++ b/server/agent_server/infra/repositories/agent_catalog.py
@@ -4,20 +4,21 @@ from agent_server.infra.repositories.store_support import *
 from agent_server.core.runtime_config import (
     DEFAULT_RUNTIME_CONFIG_SCHEMAS,
     claude_efforts_for_model,
+    codex_efforts_for_model,
 )
 
 
 class AgentCatalogRepositoryMixin:
     async def seed_agent_catalog(self) -> None:
         """Insert any catalog rows declared in SEED_AGENT_CATALOG that are
-        missing. Idempotent: re-running is a no-op once a row is present.
-        Existing rows are NOT updated, so operators can safely edit labels in
-        the DB without seeding overwriting them on next boot.
+        missing. Existing labels and descriptions remain operator-editable;
+        Codex defaults and seed ordering are migrated idempotently on startup.
         """
         await self._seed_table(agent_modes_t, SEED_AGENT_MODES)
         await self._seed_table(agent_models_t, SEED_AGENT_MODELS)
         await self._seed_table(agent_efforts_t, SEED_AGENT_EFFORTS)
-
+        async with self._engine.begin() as conn:
+            await _migrate_codex_catalog_async(conn)
 
     async def _seed_table(self, table: Any, rows: list[dict[str, Any]]) -> None:
         if not rows:
@@ -183,23 +184,26 @@ class AgentCatalogRepositoryMixin:
             )
         ).mappings().first()
         if row is not None:
-            return {
-                "runtime": runtime,
-                "enabled": bool(row["enabled"]),
-                "settings": _json_loads(row["settings_json"]) or {},
-                "models": _catalog_entries_from_json(runtime, row["models_json"]),
-            }
-        models = await self._list_agent_catalog_on_conn(conn, agent_models_t, runtime)
-        efforts = await self._list_agent_catalog_on_conn(conn, agent_efforts_t, runtime)
+            enabled = bool(row["enabled"])
+            settings = _json_loads(row["settings_json"]) or {}
+            models = _catalog_entries_from_json(runtime, row["models_json"])
+        else:
+            enabled = True
+            settings = default_agent_settings(runtime)
+            models = []
         if not models:
-            models = _default_catalog_from_runtime_schema(runtime, "model")
-        if not efforts:
-            efforts = _default_catalog_from_runtime_schema(runtime, "effort")
+            models = await self._list_agent_catalog_on_conn(conn, agent_models_t, runtime)
+            efforts = await self._list_agent_catalog_on_conn(conn, agent_efforts_t, runtime)
+            if not models:
+                models = _default_catalog_from_runtime_schema(runtime, "model")
+            if not efforts:
+                efforts = _default_catalog_from_runtime_schema(runtime, "effort")
+            models = _models_with_default_efforts(runtime, models, efforts)
         return {
             "runtime": runtime,
-            "enabled": True,
-            "settings": default_agent_settings(runtime),
-            "models": _models_with_default_efforts(runtime, models, efforts),
+            "enabled": enabled,
+            "settings": settings,
+            "models": models,
         }
 
 
@@ -385,9 +389,12 @@ def _default_efforts_for_model(
     model: str,
     efforts: list[AgentCatalogEntry],
 ) -> list[AgentCatalogEntry]:
-    if runtime != "claude":
+    if runtime == "claude":
+        allowed = claude_efforts_for_model(model)
+    elif runtime == "codex":
+        allowed = codex_efforts_for_model(model)
+    else:
         return [entry.model_copy(update={"efforts": []}) for entry in efforts]
-    allowed = claude_efforts_for_model(model)
     return [
         entry.model_copy(update={"efforts": []})
         for entry in efforts

--- a/server/agent_server/infra/repositories/agent_catalog.py
+++ b/server/agent_server/infra/repositories/agent_catalog.py
@@ -186,7 +186,14 @@ class AgentCatalogRepositoryMixin:
         if row is not None:
             enabled = bool(row["enabled"])
             settings = _json_loads(row["settings_json"]) or {}
-            models = _catalog_entries_from_json(runtime, row["models_json"])
+            # Read exact legacy built-in snapshots through the current global
+            # catalog without rewriting them, so a server rollback stays safe.
+            models = (
+                []
+                if runtime == "codex"
+                and _is_legacy_builtin_codex_models_json(row["models_json"])
+                else _catalog_entries_from_json(runtime, row["models_json"])
+            )
         else:
             enabled = True
             settings = default_agent_settings(runtime)

--- a/server/agent_server/infra/repositories/store_support.py
+++ b/server/agent_server/infra/repositories/store_support.py
@@ -71,7 +71,11 @@ from agent_server.infra.repositories import (
     InstanceSettingsRepository,
     RuntimeSettingsRepository,
 )
-from agent_server.core.runtime_config import RuntimeConfigSchema
+from agent_server.core.runtime_config import (
+    CODEX_DEFAULT_EFFORT,
+    CODEX_DEFAULT_MODEL,
+    RuntimeConfigSchema,
+)
 from agent_server.services.attachments import AttachmentService
 from agent_server.services.runtime_config import RuntimeConfigService, seed_runtime_config_schemas_sync
 from agent_server.core.utc import utc_now
@@ -95,8 +99,8 @@ def default_agent_settings(runtime: str) -> dict[str, Any]:
     if runtime == "codex":
         return {
             "permissionMode": "ask",
-            "model": None,
-            "effort": None,
+            "model": CODEX_DEFAULT_MODEL,
+            "effort": CODEX_DEFAULT_EFFORT,
         }
     if runtime == "claude":
         return {
@@ -569,11 +573,35 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
     },
     {
         "runtime": "codex",
-        "key": "gpt-5.5",
-        "display_label": "GPT-5.5",
+        "key": "gpt-5.6-sol",
+        "display_label": "GPT-5.6-Sol",
         "description": None,
         "is_default": 1,
         "sort_order": 1,
+    },
+    {
+        "runtime": "codex",
+        "key": "gpt-5.6-terra",
+        "display_label": "GPT-5.6-Terra",
+        "description": None,
+        "is_default": 0,
+        "sort_order": 2,
+    },
+    {
+        "runtime": "codex",
+        "key": "gpt-5.6-luna",
+        "display_label": "GPT-5.6-Luna",
+        "description": None,
+        "is_default": 0,
+        "sort_order": 3,
+    },
+    {
+        "runtime": "codex",
+        "key": "gpt-5.5",
+        "display_label": "GPT-5.5",
+        "description": None,
+        "is_default": 0,
+        "sort_order": 4,
     },
     {
         "runtime": "codex",
@@ -581,7 +609,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.4",
         "description": None,
         "is_default": 0,
-        "sort_order": 2,
+        "sort_order": 5,
     },
     {
         "runtime": "codex",
@@ -589,7 +617,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.4 Mini",
         "description": None,
         "is_default": 0,
-        "sort_order": 3,
+        "sort_order": 6,
     },
     {
         "runtime": "codex",
@@ -597,7 +625,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.3 Codex",
         "description": None,
         "is_default": 0,
-        "sort_order": 4,
+        "sort_order": 7,
     },
     {
         "runtime": "codex",
@@ -605,7 +633,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.2",
         "description": None,
         "is_default": 0,
-        "sort_order": 5,
+        "sort_order": 8,
     },
 ]
 
@@ -630,6 +658,7 @@ def _seed_agent_catalog_sync(async_url: str) -> None:
         with sync_engine.begin() as conn:
             for table, rows in _CATALOG_SEED_PLAN:
                 _seed_table_sync(conn, table, rows)
+            _migrate_codex_catalog_sync(conn)
     finally:
         sync_engine.dispose()
 
@@ -671,6 +700,7 @@ def _seed_agent_catalog_async_in_thread(async_url: str) -> None:
                     missing = [row for row in rows if (row["runtime"], row["key"]) not in present]
                     if missing:
                         await conn.execute(insert(table), missing)
+                await _migrate_codex_catalog_async(conn)
         finally:
             await engine.dispose()
 
@@ -741,7 +771,7 @@ SEED_AGENT_EFFORTS: list[dict[str, Any]] = [
         "key": "medium",
         "display_label": "Medium",
         "description": None,
-        "is_default": 0,
+        "is_default": 1,
         "sort_order": 2,
     },
     {
@@ -757,8 +787,24 @@ SEED_AGENT_EFFORTS: list[dict[str, Any]] = [
         "key": "xhigh",
         "display_label": "Extra high",
         "description": None,
-        "is_default": 1,
+        "is_default": 0,
         "sort_order": 4,
+    },
+    {
+        "runtime": "codex",
+        "key": "max",
+        "display_label": "Max",
+        "description": None,
+        "is_default": 0,
+        "sort_order": 5,
+    },
+    {
+        "runtime": "codex",
+        "key": "ultra",
+        "display_label": "Ultra",
+        "description": None,
+        "is_default": 0,
+        "sort_order": 6,
     },
 ]
 
@@ -768,6 +814,123 @@ _CATALOG_SEED_PLAN: tuple[tuple[Any, list[dict[str, Any]]], ...] = (
     (agent_models_t, SEED_AGENT_MODELS),
     (agent_efforts_t, SEED_AGENT_EFFORTS),
 )
+
+_LEGACY_CODEX_MODEL_SIGNATURE = (
+    ("gpt-5.5", "GPT-5.5", "", 1),
+    ("gpt-5.4", "GPT-5.4", "", 2),
+    ("gpt-5.4-mini", "GPT-5.4 Mini", "", 3),
+    ("gpt-5.3-codex", "GPT-5.3 Codex", "", 4),
+    ("gpt-5.2", "GPT-5.2", "", 5),
+)
+_LEGACY_CODEX_EFFORT_SIGNATURE = (
+    ("low", "Low", "", 1),
+    ("medium", "Medium", "", 2),
+    ("high", "High", "", 3),
+    ("xhigh", "Extra high", "", 4),
+)
+
+
+def _migrate_codex_catalog_sync(conn: Any) -> None:
+    for statement in _codex_catalog_metadata_updates():
+        conn.execute(statement)
+    now = utc_now()
+    rows = conn.execute(
+        select(user_agent_defaults_t.c.user_id, user_agent_defaults_t.c.models_json).where(
+            user_agent_defaults_t.c.runtime == "codex"
+        )
+    ).mappings().all()
+    for row in rows:
+        if not _is_legacy_builtin_codex_models_json(row["models_json"]):
+            continue
+        conn.execute(
+            update(user_agent_defaults_t)
+            .where(
+                user_agent_defaults_t.c.user_id == row["user_id"],
+                user_agent_defaults_t.c.runtime == "codex",
+            )
+            .values(models_json=_json_dumps([]), updated_at=now)
+        )
+
+
+async def _migrate_codex_catalog_async(conn: AsyncConnection) -> None:
+    for statement in _codex_catalog_metadata_updates():
+        await conn.execute(statement)
+    now = utc_now()
+    rows = (
+        await conn.execute(
+            select(user_agent_defaults_t.c.user_id, user_agent_defaults_t.c.models_json).where(
+                user_agent_defaults_t.c.runtime == "codex"
+            )
+        )
+    ).mappings().all()
+    for row in rows:
+        if not _is_legacy_builtin_codex_models_json(row["models_json"]):
+            continue
+        await conn.execute(
+            update(user_agent_defaults_t)
+            .where(
+                user_agent_defaults_t.c.user_id == row["user_id"],
+                user_agent_defaults_t.c.runtime == "codex",
+            )
+            .values(models_json=_json_dumps([]), updated_at=now)
+        )
+
+
+def _codex_catalog_metadata_updates() -> list[Any]:
+    statements: list[Any] = [
+        update(agent_models_t)
+        .where(agent_models_t.c.runtime == "codex")
+        .values(is_default=0),
+        update(agent_efforts_t)
+        .where(agent_efforts_t.c.runtime == "codex")
+        .values(is_default=0),
+    ]
+    for table, rows in (
+        (agent_models_t, SEED_AGENT_MODELS),
+        (agent_efforts_t, SEED_AGENT_EFFORTS),
+    ):
+        for row in rows:
+            if row["runtime"] != "codex":
+                continue
+            statements.append(
+                update(table)
+                .where(table.c.runtime == "codex", table.c.key == row["key"])
+                .values(is_default=row["is_default"], sort_order=row["sort_order"])
+            )
+    return statements
+
+
+def _is_legacy_builtin_codex_models_json(raw: str | None) -> bool:
+    try:
+        models = _json_loads(raw)
+    except Exception:
+        return False
+    if not isinstance(models, list) or len(models) != len(_LEGACY_CODEX_MODEL_SIGNATURE):
+        return False
+    for model, expected in zip(models, _LEGACY_CODEX_MODEL_SIGNATURE, strict=True):
+        if not isinstance(model, dict) or _catalog_item_signature(model) != expected:
+            return False
+        efforts = model.get("efforts")
+        if not isinstance(efforts, list) or tuple(
+            _catalog_item_signature(effort) for effort in efforts if isinstance(effort, dict)
+        ) != _LEGACY_CODEX_EFFORT_SIGNATURE:
+            return False
+        if any(not isinstance(effort, dict) for effort in efforts):
+            return False
+    return True
+
+
+def _catalog_item_signature(item: dict[str, Any]) -> tuple[str, str, str, int] | None:
+    try:
+        sort_order = int(item.get("sortOrder") or 0)
+    except (TypeError, ValueError):
+        return None
+    return (
+        str(item.get("key") or ""),
+        str(item.get("displayLabel") or ""),
+        str(item.get("description") or ""),
+        sort_order,
+    )
 
 
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/server/agent_server/infra/repositories/store_support.py
+++ b/server/agent_server/infra/repositories/store_support.py
@@ -833,47 +833,11 @@ _LEGACY_CODEX_EFFORT_SIGNATURE = (
 def _migrate_codex_catalog_sync(conn: Any) -> None:
     for statement in _codex_catalog_metadata_updates():
         conn.execute(statement)
-    now = utc_now()
-    rows = conn.execute(
-        select(user_agent_defaults_t.c.user_id, user_agent_defaults_t.c.models_json).where(
-            user_agent_defaults_t.c.runtime == "codex"
-        )
-    ).mappings().all()
-    for row in rows:
-        if not _is_legacy_builtin_codex_models_json(row["models_json"]):
-            continue
-        conn.execute(
-            update(user_agent_defaults_t)
-            .where(
-                user_agent_defaults_t.c.user_id == row["user_id"],
-                user_agent_defaults_t.c.runtime == "codex",
-            )
-            .values(models_json=_json_dumps([]), updated_at=now)
-        )
 
 
 async def _migrate_codex_catalog_async(conn: AsyncConnection) -> None:
     for statement in _codex_catalog_metadata_updates():
         await conn.execute(statement)
-    now = utc_now()
-    rows = (
-        await conn.execute(
-            select(user_agent_defaults_t.c.user_id, user_agent_defaults_t.c.models_json).where(
-                user_agent_defaults_t.c.runtime == "codex"
-            )
-        )
-    ).mappings().all()
-    for row in rows:
-        if not _is_legacy_builtin_codex_models_json(row["models_json"]):
-            continue
-        await conn.execute(
-            update(user_agent_defaults_t)
-            .where(
-                user_agent_defaults_t.c.user_id == row["user_id"],
-                user_agent_defaults_t.c.runtime == "codex",
-            )
-            .values(models_json=_json_dumps([]), updated_at=now)
-        )
 
 
 def _codex_catalog_metadata_updates() -> list[Any]:

--- a/server/tests/test_backend_mvp.py
+++ b/server/tests/test_backend_mvp.py
@@ -237,6 +237,8 @@ def test_platform_session_create_uses_connector_returned_session_id(tmp_path):
                 "title": "New Codex session",
                 "cwd": "/repo",
                 "approvalPolicy": "on-request",
+                "model": "gpt-5.6-sol",
+                "effort": "medium",
                 "sandbox": {
                     "type": "workspaceWrite",
                     "writableRoots": ["/repo"],
@@ -1598,13 +1600,37 @@ def test_codex_agent_catalog_lists_seeded_entries(tmp_path):
     models = client.get("/agents/codex/models", headers=headers).json()
     assert models["runtime"] == "codex"
     assert [entry["key"] for entry in models["entries"]] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.3-codex",
         "gpt-5.2",
     ]
-    assert next(e for e in models["entries"] if e["isDefault"])["key"] == "gpt-5.5"
+    assert next(e for e in models["entries"] if e["isDefault"])["key"] == "gpt-5.6-sol"
+    assert [entry["key"] for entry in models["entries"][0]["efforts"]] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    ]
+    assert [entry["key"] for entry in models["entries"][2]["efforts"]] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert [entry["key"] for entry in models["entries"][3]["efforts"]] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
 
     efforts = client.get("/agents/codex/efforts", headers=headers).json()
     assert efforts["runtime"] == "codex"
@@ -1613,8 +1639,10 @@ def test_codex_agent_catalog_lists_seeded_entries(tmp_path):
         "medium",
         "high",
         "xhigh",
+        "max",
+        "ultra",
     ]
-    assert next(e for e in efforts["entries"] if e["isDefault"])["key"] == "xhigh"
+    assert next(e for e in efforts["entries"] if e["isDefault"])["key"] == "medium"
 
 
 def test_agent_catalog_requires_authentication(tmp_path):
@@ -2601,7 +2629,7 @@ def test_ingest_adds_active_run_attachments_to_user_message(tmp_path):
     ]
 
 
-def test_send_message_omits_unspecified_overrides(tmp_path):
+def test_send_message_uses_codex_defaults_without_explicit_overrides(tmp_path):
     client = make_client(tmp_path)
     connector_id, _, session_id, headers = create_connector_and_session(client)
     fake_rpc = FakeLocalRpc()
@@ -2617,8 +2645,9 @@ def test_send_message_omits_unspecified_overrides(tmp_path):
 
     assert response.status_code == 200
     params = fake_rpc.requests[-1][2]
-    for key in ("permissionMode", "model", "effort"):
-        assert key not in params
+    assert "permissionMode" not in params
+    assert params["model"] == "gpt-5.6-sol"
+    assert params["effort"] == "medium"
     assert params["approvalPolicy"] == "on-request"
     assert params["sandboxPolicy"]["type"] == "workspaceWrite"
 

--- a/server/tests/test_runtime_config.py
+++ b/server/tests/test_runtime_config.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from typing import Any
 
 from fastapi.testclient import TestClient
+from sqlalchemy import delete, update
 
 from agent_server.app import create_app
+from agent_server.core.runtime_config import DEFAULT_RUNTIME_CONFIG_SCHEMAS
+from agent_server.infra.db import (
+    agent_efforts as agent_efforts_t,
+    agent_models as agent_models_t,
+)
 
 
 def make_client(tmp_path):
@@ -74,6 +81,33 @@ class FakeRpc:
         return {"ok": True}
 
 
+def legacy_codex_models() -> list[dict[str, Any]]:
+    efforts = [
+        {"key": "low", "displayLabel": "Low", "sortOrder": 1},
+        {"key": "medium", "displayLabel": "Medium", "sortOrder": 2},
+        {"key": "high", "displayLabel": "High", "sortOrder": 3},
+        {"key": "xhigh", "displayLabel": "Extra high", "sortOrder": 4},
+    ]
+    return [
+        {
+            "key": key,
+            "displayLabel": label,
+            "sortOrder": index,
+            "efforts": deepcopy(efforts),
+        }
+        for index, (key, label) in enumerate(
+            (
+                ("gpt-5.5", "GPT-5.5"),
+                ("gpt-5.4", "GPT-5.4"),
+                ("gpt-5.4-mini", "GPT-5.4 Mini"),
+                ("gpt-5.3-codex", "GPT-5.3 Codex"),
+                ("gpt-5.2", "GPT-5.2"),
+            ),
+            start=1,
+        )
+    ]
+
+
 def test_runtime_config_schema_is_seeded_and_readable(tmp_path):
     client = make_client(tmp_path)
     headers = auth_headers(client)
@@ -96,6 +130,8 @@ def test_user_agent_defaults_customize_schema_and_new_connectors(tmp_path):
     defaults = client.get("/agents/defaults", headers=headers)
     assert defaults.status_code == 200, defaults.text
     assert defaults.json()["runtimes"]["codex"]["enabled"] is True
+    assert defaults.json()["runtimes"]["codex"]["settings"]["model"] == "gpt-5.6-sol"
+    assert defaults.json()["runtimes"]["codex"]["settings"]["effort"] == "medium"
     assert "runMode" not in defaults.json()["runtimes"]["claude"]["settings"]
 
     updated = client.patch(
@@ -163,7 +199,8 @@ def test_user_agent_defaults_customize_schema_and_new_connectors(tmp_path):
     )
     assert codex_settings.status_code == 200, codex_settings.text
     assert codex_settings.json()["settings"]["permissionMode"] == "ask"
-    assert codex_settings.json()["settings"]["model"] is None
+    assert codex_settings.json()["settings"]["model"] == "gpt-custom"
+    assert codex_settings.json()["settings"]["effort"] == "custom-effort"
 
     claude_settings = client.get(
         f"/connectors/{connector_id}/agents/claude/settings",
@@ -228,6 +265,171 @@ def test_user_agent_defaults_ignore_default_flags(tmp_path):
         ("lowish", True),
         ("highish", False),
     ]
+
+
+def test_codex_catalog_upgrade_migrates_only_legacy_builtin_snapshots(tmp_path):
+    client = make_client(tmp_path)
+    headers = auth_headers(client)
+    legacy_update = client.patch(
+        "/agents/defaults",
+        headers=headers,
+        json={"runtimes": {"codex": {"models": legacy_codex_models()}}},
+    )
+    assert legacy_update.status_code == 200, legacy_update.text
+
+    asyncio.run(
+        client.app.state.store.create_user(
+            user_id="user2",
+            password="secret2",
+        )
+    )
+    custom_headers = auth_headers(client, user_id="user2", password="secret2")
+    custom_models = legacy_codex_models()
+    custom_models[0]["description"] = "Private deployment"
+    custom_update = client.patch(
+        "/agents/defaults",
+        headers=custom_headers,
+        json={"runtimes": {"codex": {"models": custom_models}}},
+    )
+    assert custom_update.status_code == 200, custom_update.text
+    custom_before = custom_update.json()["runtimes"]["codex"]["models"]
+
+    explicit_connector = client.post(
+        "/connectors",
+        headers=headers,
+        json={"name": "explicit"},
+    ).json()["connector"]["id"]
+    explicit = client.patch(
+        f"/connectors/{explicit_connector}/agents/codex/settings",
+        headers=headers,
+        json={"settings": {"model": "gpt-5.5", "effort": "xhigh"}},
+    )
+    assert explicit.status_code == 200, explicit.text
+
+    null_connector = client.post(
+        "/connectors",
+        headers=headers,
+        json={"name": "null-defaults"},
+    ).json()["connector"]["id"]
+    cleared = client.patch(
+        f"/connectors/{null_connector}/agents/codex/settings",
+        headers=headers,
+        json={"settings": {"model": None, "effort": None}},
+    )
+    assert cleared.status_code == 200, cleared.text
+
+    async def downgrade_and_reseed() -> None:
+        legacy_schema = deepcopy(DEFAULT_RUNTIME_CONFIG_SCHEMAS["codex"]).model_dump(
+            exclude_none=True
+        )
+        legacy_schema["schemaVersion"] = 3
+        for field in legacy_schema["fields"]:
+            if field["key"] == "model":
+                field["options"] = [
+                    option
+                    for option in field["options"]
+                    if not str(option["value"]).startswith("gpt-5.6-")
+                ]
+            elif field["key"] == "effort":
+                field["options"] = [
+                    option
+                    for option in field["options"]
+                    if option["value"] not in {"max", "ultra"}
+                ]
+        await client.app.state.store.set_runtime_config_schema("codex", legacy_schema)
+
+        async with client.app.state.store.engine.begin() as conn:
+            await conn.execute(
+                delete(agent_models_t).where(
+                    agent_models_t.c.runtime == "codex",
+                    agent_models_t.c.key.in_(
+                        {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}
+                    ),
+                )
+            )
+            await conn.execute(
+                delete(agent_efforts_t).where(
+                    agent_efforts_t.c.runtime == "codex",
+                    agent_efforts_t.c.key.in_({"max", "ultra"}),
+                )
+            )
+            await conn.execute(
+                update(agent_models_t)
+                .where(agent_models_t.c.runtime == "codex")
+                .values(is_default=0)
+            )
+            await conn.execute(
+                update(agent_efforts_t)
+                .where(agent_efforts_t.c.runtime == "codex")
+                .values(is_default=0)
+            )
+            for sort_order, key in enumerate(
+                ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"),
+                start=1,
+            ):
+                await conn.execute(
+                    update(agent_models_t)
+                    .where(agent_models_t.c.runtime == "codex", agent_models_t.c.key == key)
+                    .values(is_default=1 if key == "gpt-5.5" else 0, sort_order=sort_order)
+                )
+            await conn.execute(
+                update(agent_efforts_t)
+                .where(
+                    agent_efforts_t.c.runtime == "codex",
+                    agent_efforts_t.c.key == "xhigh",
+                )
+                .values(is_default=1)
+            )
+
+        await client.app.state.store.seed_agent_catalog()
+        await client.app.state.store.seed_runtime_config_schemas()
+        await client.app.state.store.seed_agent_catalog()
+        await client.app.state.store.seed_runtime_config_schemas()
+
+    asyncio.run(downgrade_and_reseed())
+
+    upgraded = client.get("/agents/defaults", headers=headers).json()["runtimes"]["codex"]
+    assert [model["key"] for model in upgraded["models"]][:4] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+    ]
+    assert [model["key"] for model in upgraded["models"] if model["isDefault"]] == [
+        "gpt-5.6-sol"
+    ]
+    assert [
+        effort["key"]
+        for effort in upgraded["models"][0]["efforts"]
+        if effort["isDefault"]
+    ] == ["medium"]
+
+    custom_after = client.get("/agents/defaults", headers=custom_headers).json()["runtimes"][
+        "codex"
+    ]["models"]
+    assert custom_after == custom_before
+
+    explicit_after = client.get(
+        f"/connectors/{explicit_connector}/agents/codex/settings",
+        headers=headers,
+    ).json()["settings"]
+    assert explicit_after["model"] == "gpt-5.5"
+    assert explicit_after["effort"] == "xhigh"
+
+    null_after = client.get(
+        f"/connectors/{null_connector}/agents/codex/settings",
+        headers=headers,
+    ).json()["settings"]
+    assert null_after["model"] == "gpt-5.6-sol"
+    assert null_after["effort"] == "medium"
+
+    schema = client.get("/agents/codex/config-schema", headers=headers).json()["schema"]
+    assert schema["schemaVersion"] == 4
+
+    models = asyncio.run(client.app.state.store.list_agent_models("codex"))
+    efforts = asyncio.run(client.app.state.store.list_agent_efforts("codex"))
+    assert [model.key for model in models if model.isDefault] == ["gpt-5.6-sol"]
+    assert [effort.key for effort in efforts if effort.isDefault] == ["medium"]
 
 
 def test_first_discovery_respects_user_agent_default_enabled(tmp_path):
@@ -390,6 +592,120 @@ def test_claude_effort_options_are_constrained_by_model(tmp_path):
     assert haiku_bad.status_code == 422
 
 
+def test_codex_effort_options_are_constrained_by_model(tmp_path):
+    client = make_client(tmp_path)
+    connector_id, _, session_id, headers = create_connector_and_session(client)
+
+    schema_response = client.get("/agents/codex/config-schema", headers=headers)
+    assert schema_response.status_code == 200, schema_response.text
+    schema = schema_response.json()["schema"]
+    assert schema["schemaVersion"] == 4
+    fields = {field["key"]: field for field in schema["fields"]}
+    models = {option["value"]: option for option in fields["model"]["options"]}
+    assert list(models)[:4] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+    ]
+    assert [item["value"] for item in models["gpt-5.6-sol"]["efforts"]] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    ]
+    assert [item["value"] for item in models["gpt-5.6-terra"]["efforts"]] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    ]
+    assert [item["value"] for item in models["gpt-5.6-luna"]["efforts"]] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert [item["value"] for item in models["gpt-5.5"]["efforts"]] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
+
+    accepted = (
+        ("gpt-5.6-sol", "ultra"),
+        ("gpt-5.6-terra", "ultra"),
+        ("gpt-5.6-luna", "max"),
+        ("gpt-5.5", "xhigh"),
+    )
+    for model, effort in accepted:
+        response = client.patch(
+            f"/connectors/{connector_id}/agents/codex/settings",
+            headers=headers,
+            json={"settings": {"model": model, "effort": effort}},
+        )
+        assert response.status_code == 200, response.text
+
+    rejected = (
+        ("gpt-5.6-luna", "ultra"),
+        ("gpt-5.5", "max"),
+    )
+    for model, effort in rejected:
+        response = client.patch(
+            f"/connectors/{connector_id}/agents/codex/settings",
+            headers=headers,
+            json={"settings": {"model": model, "effort": effort}},
+        )
+        assert response.status_code == 422
+
+    session_ok = client.patch(
+        f"/sessions/{session_id}/runtime-settings",
+        headers=headers,
+        json={"settings": {"model": "gpt-5.6-sol", "effort": "medium"}},
+    )
+    assert session_ok.status_code == 200, session_ok.text
+    session_bad = client.patch(
+        f"/sessions/{session_id}/runtime-settings",
+        headers=headers,
+        json={"settings": {"model": "gpt-5.6-luna", "effort": "ultra"}},
+    )
+    assert session_bad.status_code == 422
+
+
+def test_codex_sol_medium_defaults_are_sent_to_connector(tmp_path):
+    client = make_client(tmp_path)
+    connector_id, _, session_id, headers = create_connector_and_session(client)
+
+    device_settings = client.get(
+        f"/connectors/{connector_id}/agents/codex/settings",
+        headers=headers,
+    )
+    assert device_settings.status_code == 200, device_settings.text
+    assert device_settings.json()["settings"]["model"] == "gpt-5.6-sol"
+    assert device_settings.json()["settings"]["effort"] == "medium"
+
+    fake_rpc = FakeRpc()
+    client.app.state.rpc = fake_rpc
+    client.post(f"/sessions/{session_id}/takeover", headers=headers).raise_for_status()
+    sent = client.post(
+        f"/sessions/{session_id}/messages",
+        headers=headers,
+        json={"content": "use the product defaults"},
+    )
+    assert sent.status_code == 200, sent.text
+    connector_id_sent, method, params = fake_rpc.requests[-1]
+    assert connector_id_sent == connector_id
+    assert method == "turn.start"
+    assert params["model"] == "gpt-5.6-sol"
+    assert params["effort"] == "medium"
+
+
 def test_custom_model_efforts_drive_runtime_settings_validation(tmp_path):
     client = make_client(tmp_path)
     headers = auth_headers(client)
@@ -470,7 +786,11 @@ def test_session_runtime_settings_override_respects_schema(tmp_path):
 
     assert response.status_code == 200, response.text
     body = response.json()
-    assert body["runtimeSettingsOverride"] == {"permissionMode": "fullAccess"}
+    assert body["runtimeSettingsOverride"] == {
+        "permissionMode": "fullAccess",
+        "model": "gpt-5.6-sol",
+        "effort": "medium",
+    }
     assert body["runtimeSettings"]["permissionMode"] == "fullAccess"
 
     bad = client.patch(

--- a/server/tests/test_runtime_config.py
+++ b/server/tests/test_runtime_config.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from copy import deepcopy
 from typing import Any
 
 from fastapi.testclient import TestClient
-from sqlalchemy import delete, update
+from sqlalchemy import delete, select, update
 
 from agent_server.app import create_app
 from agent_server.core.runtime_config import DEFAULT_RUNTIME_CONFIG_SCHEMAS
 from agent_server.infra.db import (
     agent_efforts as agent_efforts_t,
     agent_models as agent_models_t,
+    user_agent_defaults as user_agent_defaults_t,
 )
 
 
@@ -267,7 +269,7 @@ def test_user_agent_defaults_ignore_default_flags(tmp_path):
     ]
 
 
-def test_codex_catalog_upgrade_migrates_only_legacy_builtin_snapshots(tmp_path):
+def test_codex_catalog_upgrade_inherits_only_legacy_builtin_snapshots(tmp_path):
     client = make_client(tmp_path)
     headers = auth_headers(client)
     legacy_update = client.patch(
@@ -387,6 +389,27 @@ def test_codex_catalog_upgrade_migrates_only_legacy_builtin_snapshots(tmp_path):
         await client.app.state.store.seed_runtime_config_schemas()
 
     asyncio.run(downgrade_and_reseed())
+
+    async def persisted_models(user_id: str) -> list[dict[str, Any]]:
+        async with client.app.state.store.engine.connect() as conn:
+            raw = (
+                await conn.execute(
+                    select(user_agent_defaults_t.c.models_json).where(
+                        user_agent_defaults_t.c.user_id == user_id,
+                        user_agent_defaults_t.c.runtime == "codex",
+                    )
+                )
+            ).scalar_one()
+        return json.loads(raw)
+
+    persisted_legacy_snapshot = asyncio.run(persisted_models("user1"))
+    assert [model["key"] for model in persisted_legacy_snapshot] == [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.2",
+    ]
 
     upgraded = client.get("/agents/defaults", headers=headers).json()["runtimes"]["codex"]
     assert [model["key"] for model in upgraded["models"]][:4] == [


### PR DESCRIPTION
## What changed

- add GPT-5.6-Sol, GPT-5.6-Terra, and GPT-5.6-Luna to the server Codex catalog
- make GPT-5.6-Sol + Medium the product default
- expose model-specific effort ranges:
  - Sol/Terra: Low through Ultra
  - Luna: Low through Max
  - legacy models: Low through Extra high
- bump the Codex runtime schema to v4 and validate connector/session patches against each model's supported efforts
- send the Sol/Medium defaults through session creation and turn transport

## Root cause

The iOS picker is schema-driven. The Connector asks Codex for `model/list`, but currently discards the response, while the server's fallback catalog/schema still stopped at GPT-5.5. This PR updates the server fallback; dynamic Connector synchronization remains a separate follow-up.

## Compatibility and migration

- existing non-null connector/session choices such as GPT-5.5 + Extra high remain unchanged
- null/unset model and effort values resolve to Sol + Medium
- exact legacy built-in user catalog snapshots read through to the current global catalog
- real custom user catalogs are preserved, including near-legacy catalogs with customized descriptions
- legacy snapshot JSON is not rewritten, keeping an old-server rollback viable
- catalog seeding remains idempotent and enforces one global Codex model default and one effort default

## Validation

- focused Codex/default/catalog/runtime/transport coverage: **15 passed**
- full server suite: **212 passed, 2 failed**
  - both remaining failures reproduce unchanged on `origin/main`:
    - `test_agent_catalog_rejects_unknown_runtime`
    - `test_interrupt_does_not_mark_session_idle_before_turn_end`
- syntax/undefined-name check on changed files: passed
- Python compilation and whitespace checks: passed

## Rollout

- server deployment is manual after merge; this PR does not deploy anything
- no iOS rebuild is required; the app should refetch/reopen agent settings after the server is deployed
- do not withdraw the currently reviewed iOS build for this hotfix
- follow up separately by wiring Connector `model/list` into dynamic catalog synchronization
