### PR TITLE
fix: enforce GPT-5.6 Codex runtime contracts end to end

### DIFF
--- a/connector/connector/capabilities.py
+++ b/connector/connector/capabilities.py
@@ -20,6 +20,8 @@ from connector.logging import logger
 
 _CODEX_CHECK_TIMEOUT_S = 8.0
 _COMMAND_CHECK_TIMEOUT_S = 8.0
+_CODEX_MODEL_PAGE_SIZE = 100
+_CODEX_MODEL_MAX_PAGES = 100
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,13 +133,19 @@ async def discover_codex_capability(
         result = await _check_codex_candidate(candidate)
         checked.append(result)
         if result["status"] == "ok":
+            report: dict[str, Any] = {
+                "history": "ok",
+                "execution": "ok",
+                "selected": _selected_from_check(result),
+                "checked": checked,
+            }
+            if isinstance(result.get("modelOptions"), list):
+                # Runtime reports are persisted by the server exactly at this
+                # level. Keep the selected candidate's live catalog available
+                # to device/session schema validation and clients.
+                report["modelOptions"] = result["modelOptions"]
             return (
-                {
-                    "history": "ok",
-                    "execution": "ok",
-                    "selected": _selected_from_check(result),
-                    "checked": checked,
-                },
+                report,
                 target,
             )
     return (
@@ -215,11 +223,16 @@ async def _check_codex_candidate(candidate: dict[str, str] | LaunchTarget) -> di
             client.request("thread/list", {"limit": 1, "sortKey": "updated_at"}),
             timeout=_CODEX_CHECK_TIMEOUT_S,
         )
+        model_options = await asyncio.wait_for(
+            _read_codex_model_options(client),
+            timeout=_CODEX_CHECK_TIMEOUT_S,
+        )
     except Exception as exc:
+        stage = "model-list" if "model_options" in locals() or _is_model_list_error(exc) else "app-server"
         return {
             **base,
             "status": "failed",
-            "stage": "app-server",
+            "stage": stage,
             "version": version.get("stdout"),
             "reason": _exception_reason(exc),
         }
@@ -234,7 +247,117 @@ async def _check_codex_candidate(candidate: dict[str, str] | LaunchTarget) -> di
         "status": "ok",
         "version": version.get("stdout"),
         "threadListKeys": sorted(list_result.keys()),
+        "modelOptions": model_options,
     }
+
+
+async def _read_codex_model_options(client: JsonRpcStdioClient) -> list[dict[str, Any]]:
+    """Read every model/list page from the already-started app-server.
+
+    Discovery must prove that the selected Codex can execute the catalog we
+    advertise.  Treat absent, malformed, or empty catalogs as unavailable
+    instead of defaulting to a GPT-5.6 model that an older CLI rejects.
+    """
+    options: list[dict[str, Any]] = []
+    seen_models: set[str] = set()
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    for _ in range(_CODEX_MODEL_MAX_PAGES):
+        params: dict[str, Any] = {"limit": _CODEX_MODEL_PAGE_SIZE}
+        if cursor is not None:
+            params["cursor"] = cursor
+        try:
+            result = await asyncio.wait_for(
+                client.request("model/list", params),
+                timeout=_CODEX_CHECK_TIMEOUT_S,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"model/list failed: {_exception_reason(exc)}") from exc
+        page, next_cursor = _codex_model_page(result)
+        for item in page:
+            option = _normalize_codex_model_option(item)
+            if option is None or option["hidden"]:
+                continue
+            model = option["model"]
+            if model in seen_models:
+                continue
+            seen_models.add(model)
+            options.append(option)
+        if next_cursor is None:
+            break
+        if next_cursor in seen_cursors:
+            raise RuntimeError("model/list returned a repeated cursor")
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    else:
+        raise RuntimeError("model/list exceeded pagination limit")
+    if not options:
+        raise RuntimeError("model/list returned no usable models")
+    return options
+
+
+def _codex_model_page(result: Any) -> tuple[list[Any], str | None]:
+    if not isinstance(result, dict):
+        raise RuntimeError("model/list returned a non-object response")
+    raw_models: Any = result.get("models")
+    if raw_models is None:
+        raw_models = result.get("items")
+    if raw_models is None:
+        raw_models = result.get("data")
+    if isinstance(raw_models, dict):
+        raw_models = raw_models.get("items") or raw_models.get("models")
+    if not isinstance(raw_models, list):
+        raise RuntimeError("model/list response has no models list")
+    raw_cursor = (
+        result.get("nextCursor")
+        or result.get("nextPageToken")
+        or result.get("next_page_token")
+    )
+    if raw_cursor is not None and (not isinstance(raw_cursor, str) or not raw_cursor):
+        raise RuntimeError("model/list response has an invalid next cursor")
+    return raw_models, raw_cursor
+
+
+def _normalize_codex_model_option(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    model = item.get("model") or item.get("id") or item.get("value")
+    if not isinstance(model, str) or not model:
+        return None
+    supported = item.get("supportedReasoningEfforts")
+    if supported is None:
+        supported = item.get("supported_reasoning_efforts")
+    if supported is not None and not isinstance(supported, list):
+        raise RuntimeError(f"model/list returned malformed efforts for {model}")
+    normalized_efforts: list[str] | None = None
+    if supported is not None:
+        normalized_efforts = []
+        for effort in supported:
+            if isinstance(effort, str):
+                value = effort
+            elif isinstance(effort, dict):
+                value = effort.get("reasoningEffort") or effort.get("effort")
+            else:
+                value = None
+            if not isinstance(value, str) or not value:
+                raise RuntimeError(f"model/list returned malformed effort for {model}")
+            if value not in normalized_efforts:
+                normalized_efforts.append(value)
+    default_effort = item.get("defaultReasoningEffort") or item.get("default_reasoning_effort")
+    if default_effort is not None and not isinstance(default_effort, str):
+        raise RuntimeError(f"model/list returned malformed default effort for {model}")
+    return {
+        "model": model,
+        "displayName": str(item.get("displayName") or item.get("name") or item.get("label") or model),
+        "isDefault": bool(item.get("isDefault") or item.get("default")),
+        "defaultReasoningEffort": default_effort,
+        "supportedReasoningEfforts": normalized_efforts,
+        "hidden": bool(item.get("hidden", False)),
+    }
+
+
+def _is_model_list_error(exc: BaseException) -> bool:
+    return "model/list" in str(exc)
 
 
 async def _check_claude_candidate(candidate: dict[str, str] | LaunchTarget) -> dict[str, Any]:

--- a/connector/tests/test_connector_capabilities.py
+++ b/connector/tests/test_connector_capabilities.py
@@ -62,6 +62,12 @@ def test_codex_capability_tries_app_before_cli(monkeypatch, tmp_path: Path) -> N
                 "path": str(app),
                 "status": "ok",
                 "version": "codex-cli 0.135.0-alpha.1",
+                "modelOptions": [
+                    {
+                        "model": "gpt-5.6-sol",
+                        "supportedReasoningEfforts": ["low", "medium", "ultra"],
+                    }
+                ],
             }
         return {
             "source": candidate["source"],
@@ -88,6 +94,12 @@ def test_codex_capability_tries_app_before_cli(monkeypatch, tmp_path: Path) -> N
     assert report["history"] == "ok"
     assert report["execution"] == "ok"
     assert report["selected"]["source"] == "app"
+    assert report["modelOptions"] == [
+        {
+            "model": "gpt-5.6-sol",
+            "supportedReasoningEfforts": ["low", "medium", "ultra"],
+        }
+    ]
 
 
 def test_codex_capability_reports_checked_paths_when_unavailable(monkeypatch, tmp_path: Path) -> None:
@@ -109,6 +121,186 @@ def test_codex_capability_reports_checked_paths_when_unavailable(monkeypatch, tm
     assert report["error"]["code"] == "codex_unavailable"
     assert "Plugin-based Codex installations are not supported yet" in report["error"]["message"]
     assert report["checked"][0]["status"] == "missing"
+
+
+def test_codex_capability_reads_all_model_pages_and_normalizes_constraints(monkeypatch, tmp_path: Path) -> None:
+    codex_bin = tmp_path / "codex"
+    _write_executable(codex_bin, "#!/usr/bin/env sh\nexit 0\n")
+
+    class FakeClient:
+        instances: list["FakeClient"] = []
+
+        def __init__(self, *, command: list[str]) -> None:
+            self.command = command
+            self.requests: list[tuple[str, dict[str, Any] | None]] = []
+            self.closed = False
+            self.__class__.instances.append(self)
+
+        async def start(self, _handler) -> None:
+            return None
+
+        async def request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+            self.requests.append((method, params))
+            if method == "thread/list":
+                return {"data": []}
+            if params and params.get("cursor") == "page-2":
+                return {
+                    "models": [
+                        {
+                            "model": "gpt-5.6-luna",
+                            "displayName": "GPT-5.6 Luna",
+                            "supportedReasoningEfforts": ["low", "medium", "max"],
+                            "defaultReasoningEffort": "medium",
+                        }
+                    ]
+                }
+            return {
+                "models": [
+                        {
+                            "model": "gpt-5.6-sol",
+                            "displayName": "GPT-5.6 Sol",
+                            "isDefault": True,
+                            "supportedReasoningEfforts": [
+                                {
+                                    "reasoningEffort": "low",
+                                    "description": "Fast responses with lighter reasoning",
+                                },
+                                {
+                                    "reasoningEffort": "medium",
+                                    "description": "Balances speed and reasoning depth",
+                                },
+                                {
+                                    "reasoningEffort": "ultra",
+                                    "description": "Maximum reasoning",
+                                },
+                            ],
+                        "defaultReasoningEffort": "medium",
+                    }
+                ],
+                "nextCursor": "page-2",
+            }
+
+        async def close(self) -> None:
+            self.closed = True
+
+    async def fake_version(_command: list[str]) -> dict[str, Any]:
+        return {"status": "ok", "stdout": "codex-cli 0.135.0"}
+
+    monkeypatch.setattr(capabilities, "JsonRpcStdioClient", FakeClient)
+    monkeypatch.setattr(capabilities, "_run_version", fake_version)
+
+    result = asyncio.run(capabilities._check_codex_candidate({"source": "cli", "path": str(codex_bin)}))
+
+    assert result["status"] == "ok"
+    assert [item["model"] for item in result["modelOptions"]] == ["gpt-5.6-sol", "gpt-5.6-luna"]
+    assert result["modelOptions"][0]["defaultReasoningEffort"] == "medium"
+    assert result["modelOptions"][1]["supportedReasoningEfforts"] == ["low", "medium", "max"]
+    assert [request for request in FakeClient.instances[0].requests if request[0] == "model/list"] == [
+        ("model/list", {"limit": 100}),
+        ("model/list", {"limit": 100, "cursor": "page-2"}),
+    ]
+
+
+def test_codex_capability_rejects_empty_or_malformed_model_catalog(monkeypatch, tmp_path: Path) -> None:
+    codex_bin = tmp_path / "codex"
+    _write_executable(codex_bin, "#!/usr/bin/env sh\nexit 0\n")
+
+    class EmptyCatalogClient:
+        def __init__(self, *, command: list[str]) -> None:
+            self.command = command
+
+        async def start(self, _handler) -> None:
+            return None
+
+        async def request(self, method: str, _params: dict[str, Any] | None = None) -> dict[str, Any]:
+            return {"models": []} if method == "model/list" else {}
+
+        async def close(self) -> None:
+            return None
+
+    async def fake_version(_command: list[str]) -> dict[str, Any]:
+        return {"status": "ok", "stdout": "codex-cli legacy"}
+
+    monkeypatch.setattr(capabilities, "JsonRpcStdioClient", EmptyCatalogClient)
+    monkeypatch.setattr(capabilities, "_run_version", fake_version)
+
+    result = asyncio.run(capabilities._check_codex_candidate({"source": "cli", "path": str(codex_bin)}))
+
+    assert result["status"] == "failed"
+    assert result["stage"] == "model-list"
+    assert "no usable models" in result["reason"]
+
+
+def test_codex_capability_rejects_hidden_only_model_catalog(monkeypatch, tmp_path: Path) -> None:
+    codex_bin = tmp_path / "codex"
+    _write_executable(codex_bin, "#!/usr/bin/env sh\nexit 0\n")
+
+    class HiddenCatalogClient:
+        def __init__(self, *, command: list[str]) -> None:
+            self.command = command
+
+        async def start(self, _handler) -> None:
+            return None
+
+        async def request(self, method: str, _params: dict[str, Any] | None = None) -> dict[str, Any]:
+            if method == "model/list":
+                return {"models": [{"model": "gpt-hidden", "hidden": True}]}
+            return {}
+
+        async def close(self) -> None:
+            return None
+
+    async def fake_version(_command: list[str]) -> dict[str, Any]:
+        return {"status": "ok", "stdout": "codex-cli restricted"}
+
+    monkeypatch.setattr(capabilities, "JsonRpcStdioClient", HiddenCatalogClient)
+    monkeypatch.setattr(capabilities, "_run_version", fake_version)
+
+    result = asyncio.run(capabilities._check_codex_candidate({"source": "cli", "path": str(codex_bin)}))
+
+    assert result["status"] == "failed"
+    assert result["stage"] == "model-list"
+    assert "no usable models" in result["reason"]
+
+
+def test_codex_capability_accepts_legacy_model_list_without_effort_metadata(monkeypatch, tmp_path: Path) -> None:
+    codex_bin = tmp_path / "codex"
+    _write_executable(codex_bin, "#!/usr/bin/env sh\nexit 0\n")
+
+    class LegacyCatalogClient:
+        def __init__(self, *, command: list[str]) -> None:
+            self.command = command
+
+        async def start(self, _handler) -> None:
+            return None
+
+        async def request(self, method: str, _params: dict[str, Any] | None = None) -> dict[str, Any]:
+            if method == "model/list":
+                return {"models": [{"model": "gpt-5.5", "displayName": "GPT-5.5"}]}
+            return {}
+
+        async def close(self) -> None:
+            return None
+
+    async def fake_version(_command: list[str]) -> dict[str, Any]:
+        return {"status": "ok", "stdout": "codex-cli 0.50.0"}
+
+    monkeypatch.setattr(capabilities, "JsonRpcStdioClient", LegacyCatalogClient)
+    monkeypatch.setattr(capabilities, "_run_version", fake_version)
+
+    result = asyncio.run(capabilities._check_codex_candidate({"source": "cli", "path": str(codex_bin)}))
+
+    assert result["status"] == "ok"
+    assert result["modelOptions"] == [
+        {
+            "model": "gpt-5.5",
+            "displayName": "GPT-5.5",
+            "isDefault": False,
+            "defaultReasoningEffort": None,
+            "supportedReasoningEfforts": None,
+            "hidden": False,
+        }
+    ]
 
 
 def test_codex_capability_extra_candidate_is_tried_first(monkeypatch, tmp_path: Path) -> None:

--- a/ios/Agents Anywhere/Agents Anywhere.xcodeproj/project.pbxproj
+++ b/ios/Agents Anywhere/Agents Anywhere.xcodeproj/project.pbxproj
@@ -12,12 +12,18 @@
 
 /* Begin PBXFileReference section */
 		000000000000000000000120 /* Agents Anywhere.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Agents Anywhere.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000000000000000121 /* Agents AnywhereTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Agents AnywhereTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		000000000000000000000010 /* Agents Anywhere */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "Agents Anywhere";
+			sourceTree = "<group>";
+		};
+		000000000000000000000011 /* Agents AnywhereTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Agents AnywhereTests";
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -29,6 +35,11 @@
 				000000000000000130000001 /* MarkdownUI in Frameworks */,
 			);
 		};
+		000000000000000130000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+			);
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -36,6 +47,7 @@
 			isa = PBXGroup;
 			children = (
 				000000000000000000000010 /* Agents Anywhere */,
+				000000000000000000000011 /* Agents AnywhereTests */,
 				000000000000000000000020 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -44,6 +56,7 @@
 			isa = PBXGroup;
 			children = (
 				000000000000000000000120 /* Agents Anywhere.app */,
+				000000000000000000000121 /* Agents AnywhereTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -72,7 +85,40 @@
 			productReference = 000000000000000000000120 /* Agents Anywhere.app */;
 			productType = "com.apple.product-type.application";
 		};
+		000000000000000100000001 /* Agents AnywhereTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000110000001 /* Build configuration list for PBXNativeTarget "Agents AnywhereTests" */;
+			buildPhases = (
+				000000000000000120000001 /* Sources */,
+				000000000000000130000002 /* Frameworks */,
+				000000000000000140000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				000000000000000150000001 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				000000000000000000000011 /* Agents AnywhereTests */,
+			);
+			name = "Agents AnywhereTests";
+			packageProductDependencies = (
+			);
+			productName = "Agents AnywhereTests";
+			productReference = 000000000000000000000121 /* Agents AnywhereTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
+
+/* Begin PBXContainerItemProxy section */
+		000000000000000160000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 000000000000000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 000000000000000100000000;
+			remoteInfo = "Agents Anywhere";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXProject section */
 		000000000000000000000000 /* Project object */ = {
@@ -87,6 +133,10 @@
 				TargetAttributes = {
 					000000000000000100000000 = {
 						CreatedOnToolsVersion = 26.3;
+					};
+					000000000000000100000001 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = 000000000000000100000000;
 					};
 				};
 			};
@@ -108,12 +158,18 @@
 			projectRoot = "";
 			targets = (
 				000000000000000100000000 /* Agents Anywhere */,
+				000000000000000100000001 /* Agents AnywhereTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		000000000000000140000000 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+			);
+		};
+		000000000000000140000001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
 			);
@@ -126,7 +182,20 @@
 			files = (
 			);
 		};
+		000000000000000120000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		000000000000000150000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 000000000000000100000000 /* Agents Anywhere */;
+			targetProxy = 000000000000000160000001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		000000000000000011000000 /* Debug configuration for PBXProject "Agents Anywhere" */ = {
@@ -367,6 +436,40 @@
 			};
 			name = Release;
 		};
+		000000000000000111000001 /* Debug configuration for PBXNativeTarget "Agents AnywhereTests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.6;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.t4wefan.agents-anywhere.tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Agents Anywhere.app/Agents Anywhere";
+				"TEST_HOST[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/Agents Anywhere.app/Contents/MacOS/Agents Anywhere";
+			};
+			name = Debug;
+		};
+		000000000000000112000001 /* Release configuration for PBXNativeTarget "Agents AnywhereTests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.6;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.t4wefan.agents-anywhere.tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Agents Anywhere.app/Agents Anywhere";
+				"TEST_HOST[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/Agents Anywhere.app/Contents/MacOS/Agents Anywhere";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -384,6 +487,15 @@
 				000000000000000111000000 /* Debug configuration for PBXNativeTarget "Agents Anywhere" */,
 				000000000000000112000000 /* Release configuration for PBXNativeTarget "Agents Anywhere" */,
 			);
+			defaultConfigurationName = Release;
+		};
+		000000000000000110000001 /* Build configuration list for PBXNativeTarget "Agents AnywhereTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000111000001 /* Debug configuration for PBXNativeTarget "Agents AnywhereTests" */,
+				000000000000000112000001 /* Release configuration for PBXNativeTarget "Agents AnywhereTests" */,
+			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */

--- a/ios/Agents Anywhere/Agents Anywhere.xcodeproj/xcshareddata/xcschemes/Agents Anywhere.xcscheme
+++ b/ios/Agents Anywhere/Agents Anywhere.xcodeproj/xcshareddata/xcschemes/Agents Anywhere.xcscheme
@@ -21,6 +21,20 @@
                ReferencedContainer = "container:Agents Anywhere.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+		 <BuildActionEntry
+			buildForTesting = "YES"
+			buildForRunning = "NO"
+			buildForProfiling = "NO"
+			buildForArchiving = "NO"
+			buildForAnalyzing = "YES">
+			<BuildableReference
+				BuildableIdentifier = "primary"
+				BlueprintIdentifier = "000000000000000100000001"
+				BuildableName = "Agents AnywhereTests.xctest"
+				BlueprintName = "Agents AnywhereTests"
+				ReferencedContainer = "container:Agents Anywhere.xcodeproj">
+			</BuildableReference>
+		 </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -29,6 +43,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+	  <Testables>
+		 <TestableReference
+			skipped = "NO">
+			<BuildableReference
+				BuildableIdentifier = "primary"
+				BlueprintIdentifier = "000000000000000100000001"
+				BuildableName = "Agents AnywhereTests.xctest"
+				BlueprintName = "Agents AnywhereTests"
+				ReferencedContainer = "container:Agents Anywhere.xcodeproj">
+			</BuildableReference>
+		 </TestableReference>
+	  </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/ios/Agents Anywhere/Agents Anywhere/Models/APIModels.swift
+++ b/ios/Agents Anywhere/Agents Anywhere/Models/APIModels.swift
@@ -456,6 +456,7 @@ struct RuntimeSettingsResponse: Decodable {
     let settings: JSONValue
     let runtimeSettings: JSONValue?
     let runtimeSettingsOverride: JSONValue?
+    let schema: RuntimeConfigSchema?
     let effectiveRunMode: String?
     let defaultRunModeConfigured: Bool
     let schemaVersion: Int
@@ -468,6 +469,7 @@ struct RuntimeSettingsResponse: Decodable {
         case settings
         case runtimeSettings
         case runtimeSettingsOverride
+        case schema
         case effectiveRunMode
         case defaultRunModeConfigured
         case schemaVersion
@@ -482,6 +484,7 @@ struct RuntimeSettingsResponse: Decodable {
         settings = try container.decodeOrDefault(JSONValue.self, forKey: .settings, default: .emptyObject)
         runtimeSettings = try container.decodeIfPresent(JSONValue.self, forKey: .runtimeSettings)
         runtimeSettingsOverride = try container.decodeIfPresent(JSONValue.self, forKey: .runtimeSettingsOverride)
+        schema = try container.decodeIfPresent(RuntimeConfigSchema.self, forKey: .schema)
         effectiveRunMode = try container.decodeIfPresent(String.self, forKey: .effectiveRunMode)
         defaultRunModeConfigured = try container.decodeOrDefault(Bool.self, forKey: .defaultRunModeConfigured, default: false)
         schemaVersion = try container.decodeOrDefault(Int.self, forKey: .schemaVersion, default: 0)
@@ -590,6 +593,10 @@ struct RuntimeConfigOption: Decodable, Identifiable {
     let value: JSONValue
     let label: String
     let description: String?
+    // Absent is a pre-GPT-5.6 server; callers must retain the global effort
+    // field. An empty array is an explicit "this model has no effort" signal.
+    let efforts: [RuntimeConfigOption]?
+    let isDefault: Bool?
 
     var id: String { value.stringValue ?? label }
 }

--- a/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/DashboardView.swift
+++ b/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/DashboardView.swift
@@ -1026,6 +1026,7 @@ private struct NewSessionSheet: View {
         filterRuntimeEffortField(
             runtime: selectedRuntimeValue,
             field: runtimeFields.first { $0.key == "effort" },
+            modelField: modelField,
             model: runtimeSettings["model"],
         )
     }
@@ -1071,7 +1072,15 @@ private struct NewSessionSheet: View {
             systemImage: systemImage,
             isDisabled: field?.options?.isEmpty ?? true,
             children: menuActions(for: field, selected: runtimeSettings[key]) { value in
-                runtimeSettings[key] = value
+                if key == "model" {
+                    runtimeSettings = runtimeSettingsSelectingModel(
+                        runtimeSettings,
+                        model: value,
+                        modelField: modelField
+                    )
+                } else {
+                    runtimeSettings[key] = value
+                }
             },
         )
     }
@@ -1415,7 +1424,7 @@ private struct NewSessionSheet: View {
                 let loadedSettings = try await settingsResponse
                 await MainActor.run {
                     guard selectedConnector?.id == connectorId, selectedRuntimeValue == runtime else { return }
-                    runtimeSchema = loadedSchema.schema
+                    runtimeSchema = loadedSettings.schema ?? loadedSchema.schema
                     if case let .object(object) = loadedSettings.runtimeSettings ?? loadedSettings.settings {
                         runtimeSettings = object
                     } else {

--- a/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/DashboardView.swift
+++ b/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/DashboardView.swift
@@ -110,18 +110,12 @@ private struct RootTabsView: View {
                 .transition(tabTransition)
             }
 
-            if #available(iOS 27.0, *) {
-                Tab("New", systemImage: "plus", value: RootTab.newSession, role: .prominent) {
-                    mirroredActionTabRoot
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
-                }
-            } else {
-                Tab("New", systemImage: "plus", value: RootTab.newSession) {
-                    mirroredActionTabRoot
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
-                }
+            // The currently supported SwiftUI SDK only exposes `TabRole.search`.
+            // Keep New as the same selection-driven action tab on every SDK.
+            Tab("New", systemImage: "plus", value: RootTab.newSession) {
+                mirroredActionTabRoot
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
             }
         }
         .animation(rootTabAnimation, value: selectedTab)

--- a/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/SessionDetailView.swift
+++ b/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/SessionDetailView.swift
@@ -324,6 +324,7 @@ struct SessionDetailView: View {
         filterRuntimeEffortField(
             runtime: session.runtime,
             field: runtimeFields.first { $0.key == "effort" },
+            modelField: modelField,
             model: runtimeSettingsObject["model"],
         )
     }
@@ -627,7 +628,7 @@ struct SessionDetailView: View {
             async let settingsResponse = api.getSessionRuntimeSettings(token: token, sessionId: initialSession.id)
             let loadedSchema = try await schemaResponse
             let loadedSettings = try await settingsResponse
-            runtimeSchema = loadedSchema.schema
+            runtimeSchema = loadedSettings.schema ?? loadedSchema.schema
             runtimeSettings = loadedSettings
         } catch {
             errorMessage = error.localizedDescription
@@ -645,6 +646,7 @@ struct SessionDetailView: View {
                 settings: [key: value],
             )
             runtimeSettings = response
+            runtimeSchema = response.schema ?? runtimeSchema
             session = session.updatingRuntimeSettings(from: response)
         } catch {
             errorMessage = error.localizedDescription
@@ -2668,16 +2670,64 @@ func runtimeConfigFieldIsVisible(_ field: RuntimeConfigField, settings: [String:
 func filterRuntimeEffortField(
     runtime: String,
     field: RuntimeConfigField?,
+    modelField: RuntimeConfigField? = nil,
     model: JSONValue?
 ) -> RuntimeConfigField? {
     guard let field else { return nil }
-    guard runtime == "claude", field.key == "effort" else { return field }
+    guard field.key == "effort" else { return field }
+
+    if let modelValue = model?.stringValue,
+       let modelOption = modelField.flatMap({ fieldForModelOption(modelValue, in: $0) }),
+       let constrainedEfforts = modelOption.efforts
+    {
+        // An explicit empty nested list means this model does not expose an
+        // effort selector. A missing nested list is legacy/unknown and falls
+        // through to the global field below.
+        return constrainedEfforts.isEmpty ? nil : field.withOptions(constrainedEfforts)
+    }
+
+    // Older server schemas do not carry nested constraints. Keep the legacy
+    // Claude behavior as a compatibility fallback only; all modern runtimes
+    // use the server-provided model option contract above.
+    guard runtime == "claude" else { return field }
     let allowed = claudeEffortValues(for: model?.stringValue)
     guard !allowed.isEmpty else { return nil }
     return field.withOptions(field.options?.filter { option in
         guard let value = option.value.stringValue else { return false }
         return allowed.contains(value)
     } ?? [])
+}
+
+private func fieldForModelOption(_ model: String, in field: RuntimeConfigField) -> RuntimeConfigOption? {
+    field.options?.first { $0.value.stringValue == model }
+}
+
+func runtimeSettingsSelectingModel(
+    _ settings: [String: JSONValue],
+    model: JSONValue,
+    modelField: RuntimeConfigField?
+) -> [String: JSONValue] {
+    var result = settings
+    result["model"] = model
+    guard let modelValue = model.stringValue,
+          let option = modelField.flatMap({ fieldForModelOption(modelValue, in: $0) }),
+          let efforts = option.efforts
+    else { return result }
+
+    guard !efforts.isEmpty else {
+        result.removeValue(forKey: "effort")
+        return result
+    }
+    let allowed = Set(efforts.compactMap { $0.value.stringValue })
+    if let current = result["effort"]?.stringValue, allowed.contains(current) {
+        return result
+    }
+    if let fallback = efforts.first(where: { $0.isDefault == true }) ?? efforts.first {
+        result["effort"] = fallback.value
+    } else {
+        result.removeValue(forKey: "effort")
+    }
+    return result
 }
 
 private func claudeEffortValues(for model: String?) -> Set<String> {

--- a/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/SessionDetailView.swift
+++ b/ios/Agents Anywhere/Agents Anywhere/Views/Dashboard/SessionDetailView.swift
@@ -133,115 +133,32 @@ struct SessionDetailView: View {
 
     var body: some View {
         ScrollViewReader { proxy in
-            ZStack(alignment: .bottomTrailing) {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 18) {
-                        if isLoading && displayEntries.isEmpty {
-                            ProgressView()
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 60)
-                        } else if displayEntries.isEmpty {
-                            ContentUnavailableView(
-                                "No Messages Yet",
-                                systemImage: "bubble.left.and.bubble.right",
-                                description: Text("Messages from this session will appear here."),
-                            )
-                            .padding(.top, 80)
-                        } else {
-                            if timeline.hasMore || isLoadingOlder {
-                                ProgressView()
-                                    .opacity(isLoadingOlder ? 1 : 0)
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 12)
-                                .id("load-older")
-                            }
-
-                            ForEach(displayEntries) { entry in
-                                ChatEntryView(
-                                    entry: entry,
-                                    api: appState.api,
-                                    token: appState.accessToken(),
-                                    resolvingApprovalId: resolvingApprovalId,
-                                    resolvingApprovalStatus: resolvingApprovalStatus,
-                                    onResolveApproval: { approval, status in
-                                        Task { await resolveApproval(approval, status: status) }
-                                    },
-                                    onPreviewAttachment: { url in
-                                        attachmentPreviewURL = url
-                                    },
-                                )
-                                    .id(entry.id)
-                            }
-
-                            if session.status == "running" {
-                                WorkingIndicator(runtime: session.runtime)
-                                    .id("working")
-                            }
-                        }
-
-                        Color.clear
-                            .frame(height: 1)
-                            .id(timelineBottomAnchorID)
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 14)
-                    .background {
-                        GeometryReader { geometry in
-                            Color.clear.preference(
-                                key: TimelineContentHeightPreferenceKey.self,
-                                value: geometry.size.height,
-                            )
-                        }
-                    }
-                    .opacity(isTimelineReadyForDisplay || displayEntries.isEmpty ? 1 : 0)
-                    .allowsHitTesting(isTimelineReadyForDisplay || displayEntries.isEmpty)
-                }
-                .contentShape(Rectangle())
-                .simultaneousGesture(
-                    TapGesture().onEnded {
-                        dismissComposerKeyboard()
-                    },
-                )
-                .onScrollGeometryChange(for: Bool.self) { geometry in
-                    distanceToBottom(geometry) <= scrollBottomButtonDistance
-                } action: { _, isNearBottom in
-                    isTimelineNearBottom = isNearBottom
-                }
-                .onScrollGeometryChange(for: Bool.self) { geometry in
-                    distanceToBottom(geometry) <= autoScrollBottomDistance
-                } action: { _, isNearEnoughForAutoScroll in
-                    isTimelineWithinAutoScrollDistance = isNearEnoughForAutoScroll
-                }
-                .onScrollGeometryChange(for: Bool.self) { geometry in
-                    geometry.visibleRect.minY <= loadOlderScrollThreshold
-                } action: { _, isNearTop in
-                    guard isNearTop, isTimelineReadyForDisplay, !displayEntries.isEmpty else { return }
-                    Task { await loadOlderTimeline(proxy) }
-                }
-
-                if shouldShowScrollToBottomButton {
-                    Button {
-                        shouldForceScrollOnTimelineUpdate = false
-                        shouldAutoScrollOnTimelineUpdate = false
-                        scrollToBottom(proxy, animated: true)
-                    } label: {
-                        Image(systemName: "arrow.down")
-                            .font(.system(size: 17, weight: .semibold))
-                            .frame(width: 44, height: 44)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.primary)
-                    .frame(width: 56, height: 56)
-                    .contentShape(Circle())
-                    .composerGlassEffect(shape: Circle())
-                    .accessibilityLabel("Scroll to Bottom")
-                    .padding(.trailing, 18)
-                    .padding(.bottom, 12)
-                    .zIndex(10)
-                    .transition(.scale(scale: 0.92).combined(with: .opacity))
-                }
-            }
-            .animation(.smooth(duration: 0.18), value: shouldShowScrollToBottomButton)
+            SessionTimelineContent(
+                proxy: proxy,
+                isLoading: isLoading,
+                entries: displayEntries,
+                hasMore: timeline.hasMore,
+                isLoadingOlder: isLoadingOlder,
+                isRunning: session.status == "running",
+                runtime: session.runtime,
+                isTimelineReadyForDisplay: isTimelineReadyForDisplay,
+                shouldShowScrollToBottomButton: shouldShowScrollToBottomButton,
+                api: appState.api,
+                token: appState.accessToken(),
+                resolvingApprovalId: resolvingApprovalId,
+                resolvingApprovalStatus: resolvingApprovalStatus,
+                onResolveApproval: resolveTimelineApproval,
+                onPreviewAttachment: previewTimelineAttachment,
+                onDismissKeyboard: dismissComposerKeyboard,
+                onNearBottomChanged: { isTimelineNearBottom = $0 },
+                onNearAutoScrollDistanceChanged: { isTimelineWithinAutoScrollDistance = $0 },
+                onLoadOlder: { Task { await loadOlderTimeline(proxy) } },
+                onScrollToBottom: {
+                    shouldForceScrollOnTimelineUpdate = false
+                    shouldAutoScrollOnTimelineUpdate = false
+                    scrollToBottom(proxy, animated: true)
+                },
+            )
             .onChange(of: timelineRevision) { _, _ in
                 reconcileTimelineScroll(proxy)
             }
@@ -249,32 +166,15 @@ struct SessionDetailView: View {
                 timelineContentHeight = height
             }
             .onChange(of: session.status) { _, _ in
-                if isInterrupting && !serverBusy {
-                    isInterrupting = false
-                }
+                handleSessionStatusChange()
             }
             .task {
-                hasPositionedInitialScroll = false
-                isTimelineReadyForDisplay = false
-                shouldForceScrollOnTimelineUpdate = true
-                pendingPrependAnchorID = nil
-                await markRead()
-                await loadState(replace: true)
-                lastEntryRefreshAt = Date()
-                Task { await loadRuntimeSettingsIfNeeded() }
-                startEventStream()
+                await prepareInitialSession()
             }
             .onChange(of: scenePhase) { _, phase in
-                if phase == .active {
-                    Task { await refreshOnEntry() }
-                }
+                handleScenePhaseChange(phase)
             }
-            .onDisappear {
-                initialBottomScrollGeneration += 1
-                isSettlingInitialBottomScroll = false
-                sseTask?.cancel()
-                pollTask?.cancel()
-            }
+            .onDisappear(perform: handleSessionDetailDisappear)
         }
         .navigationTitle(session.displayTitle)
         .navigationBarTitleDisplayMode(.inline)
@@ -426,6 +326,44 @@ struct SessionDetailView: View {
             field: runtimeFields.first { $0.key == "effort" },
             model: runtimeSettingsObject["model"],
         )
+    }
+
+    private func resolveTimelineApproval(_ approval: Approval, _ status: ApprovalResolveStatus) {
+        Task { await resolveApproval(approval, status: status) }
+    }
+
+    private func previewTimelineAttachment(_ url: URL) {
+        attachmentPreviewURL = url
+    }
+
+    private func prepareInitialSession() async {
+        hasPositionedInitialScroll = false
+        isTimelineReadyForDisplay = false
+        shouldForceScrollOnTimelineUpdate = true
+        pendingPrependAnchorID = nil
+        await markRead()
+        await loadState(replace: true)
+        lastEntryRefreshAt = Date()
+        Task { await loadRuntimeSettingsIfNeeded() }
+        startEventStream()
+    }
+
+    private func handleSessionStatusChange() {
+        if isInterrupting && !serverBusy {
+            isInterrupting = false
+        }
+    }
+
+    private func handleScenePhaseChange(_ phase: ScenePhase) {
+        guard phase == .active else { return }
+        Task { await refreshOnEntry() }
+    }
+
+    private func handleSessionDetailDisappear() {
+        initialBottomScrollGeneration += 1
+        isSettlingInitialBottomScroll = false
+        sseTask?.cancel()
+        pollTask?.cancel()
     }
 
     private var messageInputActions: [MessageInputAction] {
@@ -1182,6 +1120,159 @@ private struct SessionTimelineState {
             return itemsById.values.contains { $0.matchesOptimisticMessage(optimistic.id) }
         }
         return optimisticItems != before
+    }
+}
+
+private struct SessionTimelineContent: View {
+    let proxy: ScrollViewProxy
+    let isLoading: Bool
+    let entries: [ChatEntry]
+    let hasMore: Bool
+    let isLoadingOlder: Bool
+    let isRunning: Bool
+    let runtime: String
+    let isTimelineReadyForDisplay: Bool
+    let shouldShowScrollToBottomButton: Bool
+    let api: APIClient?
+    let token: String?
+    let resolvingApprovalId: String?
+    let resolvingApprovalStatus: ApprovalResolveStatus?
+    let onResolveApproval: (Approval, ApprovalResolveStatus) -> Void
+    let onPreviewAttachment: (URL) -> Void
+    let onDismissKeyboard: () -> Void
+    let onNearBottomChanged: (Bool) -> Void
+    let onNearAutoScrollDistanceChanged: (Bool) -> Void
+    let onLoadOlder: () -> Void
+    let onScrollToBottom: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 18) {
+                    if isLoading && entries.isEmpty {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 60)
+                    } else if entries.isEmpty {
+                        ContentUnavailableView(
+                            "No Messages Yet",
+                            systemImage: "bubble.left.and.bubble.right",
+                            description: Text("Messages from this session will appear here."),
+                        )
+                        .padding(.top, 80)
+                    } else {
+                        if hasMore || isLoadingOlder {
+                            ProgressView()
+                                .opacity(isLoadingOlder ? 1 : 0)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                            .id("load-older")
+                        }
+
+                        ForEach(entries) { entry in
+                            TimelineEntryRow(
+                                entry: entry,
+                                api: api,
+                                token: token,
+                                resolvingApprovalId: resolvingApprovalId,
+                                resolvingApprovalStatus: resolvingApprovalStatus,
+                                onResolveApproval: onResolveApproval,
+                                onPreviewAttachment: onPreviewAttachment,
+                            )
+                        }
+
+                        if isRunning {
+                            WorkingIndicator(runtime: runtime)
+                                .id("working")
+                        }
+                    }
+
+                    Color.clear
+                        .frame(height: 1)
+                        .id(timelineBottomAnchorID)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 14)
+                .background {
+                    GeometryReader { geometry in
+                        Color.clear.preference(
+                            key: TimelineContentHeightPreferenceKey.self,
+                            value: geometry.size.height,
+                        )
+                    }
+                }
+                .opacity(isTimelineReadyForDisplay || entries.isEmpty ? 1 : 0)
+                .allowsHitTesting(isTimelineReadyForDisplay || entries.isEmpty)
+            }
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    onDismissKeyboard()
+                },
+            )
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                distanceToBottom(geometry) <= scrollBottomButtonDistance
+            } action: { _, isNearBottom in
+                onNearBottomChanged(isNearBottom)
+            }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                distanceToBottom(geometry) <= autoScrollBottomDistance
+            } action: { _, isNearEnoughForAutoScroll in
+                onNearAutoScrollDistanceChanged(isNearEnoughForAutoScroll)
+            }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.visibleRect.minY <= loadOlderScrollThreshold
+            } action: { _, isNearTop in
+                guard isNearTop, isTimelineReadyForDisplay, !entries.isEmpty else { return }
+                onLoadOlder()
+            }
+
+            if shouldShowScrollToBottomButton {
+                Button(action: onScrollToBottom) {
+                    Image(systemName: "arrow.down")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.primary)
+                .frame(width: 56, height: 56)
+                .contentShape(Circle())
+                .composerGlassEffect(shape: Circle())
+                .accessibilityLabel("Scroll to Bottom")
+                .padding(.trailing, 18)
+                .padding(.bottom, 12)
+                .zIndex(10)
+                .transition(.scale(scale: 0.92).combined(with: .opacity))
+            }
+        }
+        .animation(.smooth(duration: 0.18), value: shouldShowScrollToBottomButton)
+    }
+
+    private func distanceToBottom(_ geometry: ScrollGeometry) -> CGFloat {
+        max(0, geometry.contentSize.height - geometry.visibleRect.maxY)
+    }
+}
+
+private struct TimelineEntryRow: View {
+    let entry: ChatEntry
+    let api: APIClient?
+    let token: String?
+    let resolvingApprovalId: String?
+    let resolvingApprovalStatus: ApprovalResolveStatus?
+    let onResolveApproval: (Approval, ApprovalResolveStatus) -> Void
+    let onPreviewAttachment: (URL) -> Void
+
+    var body: some View {
+        ChatEntryView(
+            entry: entry,
+            api: api,
+            token: token,
+            resolvingApprovalId: resolvingApprovalId,
+            resolvingApprovalStatus: resolvingApprovalStatus,
+            onResolveApproval: onResolveApproval,
+            onPreviewAttachment: onPreviewAttachment,
+        )
+        .id(entry.id)
     }
 }
 

--- a/ios/Agents Anywhere/Agents AnywhereTests/RuntimeConfigContractTests.swift
+++ b/ios/Agents Anywhere/Agents AnywhereTests/RuntimeConfigContractTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+@testable import Agents_Anywhere
+
+@MainActor
+final class RuntimeConfigContractTests: XCTestCase {
+    func testDecodesNestedEffortsAndDefaultFlags() throws {
+        let data = Data(
+            """
+            {
+              "value":"gpt-5.6-luna",
+              "label":"GPT-5.6 Luna",
+              "isDefault":false,
+              "efforts":[
+                {"value":"low","label":"Low"},
+                {"value":"medium","label":"Medium","isDefault":true}
+              ]
+            }
+            """.utf8
+        )
+
+        let option = try JSONDecoder().decode(RuntimeConfigOption.self, from: data)
+
+        XCTAssertEqual(option.value.stringValue, "gpt-5.6-luna")
+        XCTAssertEqual(option.isDefault, false)
+        XCTAssertEqual(option.efforts?.map { $0.value.stringValue }, ["low", "medium"])
+        XCTAssertEqual(option.efforts?.first(where: { $0.isDefault == true })?.value.stringValue, "medium")
+    }
+
+    func testRuntimeSettingsResponseDecodesDeviceEffectiveSchema() throws {
+        let data = Data(
+            """
+            {
+              "runtime":"codex",
+              "settings":{"model":"gpt-5.6-luna","effort":"medium"},
+              "schema":{
+                "runtime":"codex",
+                "schemaVersion":4,
+                "fields":[
+                  {
+                    "key":"model",
+                    "label":"Model",
+                    "type":"enum",
+                    "options":[
+                      {
+                        "value":"gpt-5.6-luna",
+                        "label":"GPT-5.6 Luna",
+                        "efforts":[{"value":"medium","label":"Medium","isDefault":true}]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "schemaVersion":4,
+              "serverTime":"2026-08-02T00:00:00Z"
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(RuntimeSettingsResponse.self, from: data)
+        let model = response.schema?.fields.first?.options?.first
+
+        XCTAssertEqual(response.schema?.schemaVersion, 4)
+        XCTAssertEqual(model?.value.stringValue, "gpt-5.6-luna")
+        XCTAssertEqual(model?.efforts?.first?.value.stringValue, "medium")
+    }
+
+    func testFiltersEffortUsingNestedModelConstraintForEveryRuntime() {
+        let effortField = RuntimeConfigField(
+            key: "effort",
+            label: "Effort",
+            type: "enum",
+            description: nil,
+            options: [
+                RuntimeConfigOption(value: .string("low"), label: "Low", description: nil, efforts: nil, isDefault: false),
+                RuntimeConfigOption(value: .string("medium"), label: "Medium", description: nil, efforts: nil, isDefault: true),
+                RuntimeConfigOption(value: .string("ultra"), label: "Ultra", description: nil, efforts: nil, isDefault: false),
+            ],
+            runtimeOptionsSource: nil,
+            visibleWhen: nil,
+            allowSessionOverride: true,
+            hidden: nil,
+            fields: nil
+        )
+        let modelField = RuntimeConfigField(
+            key: "model",
+            label: "Model",
+            type: "enum",
+            description: nil,
+            options: [
+                RuntimeConfigOption(
+                    value: .string("gpt-5.6-luna"),
+                    label: "GPT-5.6 Luna",
+                    description: nil,
+                    efforts: [
+                        RuntimeConfigOption(value: .string("low"), label: "Low", description: nil, efforts: nil, isDefault: false),
+                        RuntimeConfigOption(value: .string("medium"), label: "Medium", description: nil, efforts: nil, isDefault: true),
+                    ],
+                    isDefault: false
+                ),
+            ],
+            runtimeOptionsSource: nil,
+            visibleWhen: nil,
+            allowSessionOverride: true,
+            hidden: nil,
+            fields: nil
+        )
+
+        let schema = RuntimeConfigSchema(runtime: "codex", schemaVersion: 4, fields: [modelField, effortField])
+        let filtered = filterRuntimeEffortField(
+            runtime: "codex",
+            field: effortField,
+            modelField: modelField,
+            model: .string("gpt-5.6-luna")
+        )
+
+        XCTAssertEqual(schema.fields.first?.key, "model")
+        XCTAssertEqual(filtered?.options?.map { $0.value.stringValue }, ["low", "medium"])
+    }
+
+    func testExplicitEmptyNestedEffortsHidesSelector() {
+        let field = RuntimeConfigField(
+            key: "effort",
+            label: "Effort",
+            type: "enum",
+            description: nil,
+            options: [
+                RuntimeConfigOption(value: .string("gpt-no-effort"), label: "No effort", description: nil, efforts: [], isDefault: false),
+            ],
+            runtimeOptionsSource: nil,
+            visibleWhen: nil,
+            allowSessionOverride: true,
+            hidden: nil,
+            fields: nil
+        )
+
+        XCTAssertNil(
+            filterRuntimeEffortField(
+                runtime: "codex",
+                field: field,
+                modelField: field,
+                model: .string("gpt-no-effort")
+            )
+        )
+    }
+
+    func testModelSelectionNormalizesEffortBeforeCreatePayload() {
+        let modelField = RuntimeConfigField(
+            key: "model",
+            label: "Model",
+            type: "enum",
+            description: nil,
+            options: [
+                RuntimeConfigOption(
+                    value: .string("gpt-5.6-luna"),
+                    label: "GPT-5.6 Luna",
+                    description: nil,
+                    efforts: [
+                        RuntimeConfigOption(value: .string("low"), label: "Low", description: nil, efforts: nil, isDefault: false),
+                        RuntimeConfigOption(value: .string("medium"), label: "Medium", description: nil, efforts: nil, isDefault: true),
+                    ],
+                    isDefault: false
+                ),
+                RuntimeConfigOption(
+                    value: .string("gpt-no-effort"),
+                    label: "No Effort",
+                    description: nil,
+                    efforts: [],
+                    isDefault: false
+                ),
+            ],
+            runtimeOptionsSource: nil,
+            visibleWhen: nil,
+            allowSessionOverride: true,
+            hidden: nil,
+            fields: nil
+        )
+
+        let lunaPayload = runtimeSettingsSelectingModel(
+            ["model": .string("gpt-5.6-sol"), "effort": .string("ultra")],
+            model: .string("gpt-5.6-luna"),
+            modelField: modelField
+        )
+        XCTAssertEqual(lunaPayload["model"], .string("gpt-5.6-luna"))
+        XCTAssertEqual(lunaPayload["effort"], .string("medium"))
+
+        let noEffortPayload = runtimeSettingsSelectingModel(
+            lunaPayload,
+            model: .string("gpt-no-effort"),
+            modelField: modelField
+        )
+        XCTAssertEqual(noEffortPayload["model"], .string("gpt-no-effort"))
+        XCTAssertNil(noEffortPayload["effort"])
+    }
+}

--- a/server/agent_server/api/agents.py
+++ b/server/agent_server/api/agents.py
@@ -14,6 +14,7 @@ from agent_server.core.models import (
     UserAgentDefaultRuntime,
 )
 from agent_server.core.runtime_config import (
+    PersistedRuntimeConfigError,
     RuntimeConfigSchemaResponse,
     schema_with_user_agent_defaults,
 )
@@ -23,6 +24,12 @@ from agent_server.core.utc import utc_now
 
 
 router = APIRouter(prefix="/agents", tags=["agents"])
+_CATALOG_RUNTIMES = {"codex", "claude"}
+
+
+def _require_catalog_runtime(runtime: str) -> None:
+    if runtime not in _CATALOG_RUNTIMES:
+        raise HTTPException(status_code=422, detail=f"unsupported catalog runtime: {runtime}")
 
 
 @router.get("/defaults", response_model=UserAgentDefaultsResponse)
@@ -30,8 +37,12 @@ async def get_agent_defaults(
     user_id: str = Depends(current_user_id),
     db: Store = Depends(get_store),
 ) -> UserAgentDefaultsResponse:
+    try:
+        defaults = await db.get_user_agent_defaults(user_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     return UserAgentDefaultsResponse(
-        runtimes=_agent_defaults_response(await db.get_user_agent_defaults(user_id)),
+        runtimes=_agent_defaults_response(defaults),
         serverTime=utc_now(),
     )
 
@@ -50,6 +61,8 @@ async def update_agent_defaults(
                 for runtime, item in payload.runtimes.items()
             },
         )
+    except PersistedRuntimeConfigError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except KeyError:
@@ -66,6 +79,7 @@ async def list_agent_modes(
     _user_id: str = Depends(current_user_id),
     db: Store = Depends(get_store),
 ) -> AgentCatalogResponse:
+    _require_catalog_runtime(runtime)
     return AgentCatalogResponse(
         runtime=runtime,
         entries=await db.list_agent_modes(runtime),
@@ -79,7 +93,11 @@ async def list_agent_models(
     user_id: str = Depends(current_user_id),
     db: Store = Depends(get_store),
 ) -> AgentCatalogResponse:
-    defaults = await db.get_user_agent_defaults(user_id)
+    _require_catalog_runtime(runtime)
+    try:
+        defaults = await db.get_user_agent_defaults(user_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     runtime_defaults = defaults.get(runtime)
     if runtime_defaults and runtime_defaults.get("models"):
         return AgentCatalogResponse(
@@ -100,7 +118,11 @@ async def list_agent_efforts(
     user_id: str = Depends(current_user_id),
     db: Store = Depends(get_store),
 ) -> AgentCatalogResponse:
-    defaults = await db.get_user_agent_defaults(user_id)
+    _require_catalog_runtime(runtime)
+    try:
+        defaults = await db.get_user_agent_defaults(user_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     runtime_defaults = defaults.get(runtime)
     if runtime_defaults and runtime_defaults.get("models"):
         return AgentCatalogResponse(

--- a/server/agent_server/api/connectors.py
+++ b/server/agent_server/api/connectors.py
@@ -63,7 +63,11 @@ from agent_server.core.models import (
     TerminalResizeRequest,
     TerminalResponse,
 )
-from agent_server.core.runtime_config import RuntimeSettingsPatchRequest, RuntimeSettingsResponse
+from agent_server.core.runtime_config import (
+    PersistedRuntimeConfigError,
+    RuntimeSettingsPatchRequest,
+    RuntimeSettingsResponse,
+)
 from agent_server.services.runtime_activation import send_active_runtimes
 from agent_server.services.connector_presence import with_effective_connector_status, with_effective_session_connector_status
 from agent_server.services.dashboard_events import publish_dashboard_changed
@@ -1466,6 +1470,8 @@ async def patch_connector_agent_settings(
         )
     except KeyError:
         raise HTTPException(status_code=404, detail="connector not found") from None
+    except PersistedRuntimeConfigError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     return RuntimeSettingsResponse(

--- a/server/agent_server/api/sessions.py
+++ b/server/agent_server/api/sessions.py
@@ -29,7 +29,11 @@ from agent_server.core.models import (
     SessionStateResponse,
     TakeoverResponse,
 )
-from agent_server.core.runtime_config import RuntimeSettingsPatchRequest, RuntimeSettingsResponse
+from agent_server.core.runtime_config import (
+    PersistedRuntimeConfigError,
+    RuntimeSettingsPatchRequest,
+    RuntimeSettingsResponse,
+)
 from agent_server.services.runtime_config import RuntimeConfigService
 from agent_server.services.session_run import SessionRunError, SessionRunService
 from agent_server.services.connector_presence import with_effective_session_connector_status
@@ -334,6 +338,8 @@ async def patch_session_runtime_settings(
         )
     except KeyError:
         raise HTTPException(status_code=404, detail="session not found") from None
+    except PersistedRuntimeConfigError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/server/agent_server/core/runtime_config.py
+++ b/server/agent_server/core/runtime_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from copy import deepcopy
 from typing import Annotated, Any, Literal
@@ -24,10 +25,21 @@ CODEX_DEFAULT_MODEL = "gpt-5.6-sol"
 CODEX_DEFAULT_EFFORT = "medium"
 
 
+class PersistedRuntimeConfigError(ValueError):
+    """Stored runtime configuration is corrupt or no longer decodable."""
+
+
 class RuntimeConfigOption(BaseModel):
     value: str | bool
     label: str
     description: str | None = None
+    # `isDefault` is deliberately optional-on-the-wire: older servers did not
+    # expose it, while newer clients need a deterministic fallback when a
+    # model switch invalidates the previous reasoning effort.
+    isDefault: bool = False
+    # None means the runtime did not describe per-model effort constraints and
+    # the top-level effort field remains authoritative. An empty list means the
+    # model explicitly does not support a reasoning-effort setting.
     efforts: list["RuntimeConfigOption"] | None = None
 
 
@@ -307,7 +319,7 @@ DEFAULT_RUNTIME_CONFIG_SCHEMAS: dict[str, RuntimeConfigSchema] = {
                 type="enum",
                 allowSessionOverride=True,
                 options=[
-                    RuntimeConfigOption(value="gpt-5.6-sol", label="GPT-5.6-Sol"),
+                    RuntimeConfigOption(value="gpt-5.6-sol", label="GPT-5.6-Sol", isDefault=True),
                     RuntimeConfigOption(value="gpt-5.6-terra", label="GPT-5.6-Terra"),
                     RuntimeConfigOption(value="gpt-5.6-luna", label="GPT-5.6-Luna"),
                     RuntimeConfigOption(value="gpt-5.5", label="GPT-5.5"),
@@ -324,7 +336,7 @@ DEFAULT_RUNTIME_CONFIG_SCHEMAS: dict[str, RuntimeConfigSchema] = {
                 allowSessionOverride=True,
                 options=[
                     RuntimeConfigOption(value="low", label="Low"),
-                    RuntimeConfigOption(value="medium", label="Medium"),
+                    RuntimeConfigOption(value="medium", label="Medium", isDefault=True),
                     RuntimeConfigOption(value="high", label="High"),
                     RuntimeConfigOption(value="xhigh", label="Extra high"),
                     RuntimeConfigOption(value="max", label="Max"),
@@ -334,6 +346,94 @@ DEFAULT_RUNTIME_CONFIG_SCHEMAS: dict[str, RuntimeConfigSchema] = {
         ],
     ),
 }
+
+
+def _rollback_safe_runtime_config_schemas() -> dict[str, RuntimeConfigSchema]:
+    """Return the schema shape a pre-GPT-5.6 server can safely consume.
+
+    The current service projects GPT-5.6 into memory, but startup seeds only
+    this Codex v3 representation.  A rollback therefore sees its familiar
+    catalog rather than rows it cannot validate.
+    """
+    result = deepcopy(DEFAULT_RUNTIME_CONFIG_SCHEMAS)
+    codex = result["codex"]
+    codex.schemaVersion = 3
+    for field in codex.fields:
+        if field.key == "model":
+            field.options = [
+                # v3 persistence deliberately carries no new-only default
+                # metadata. The preceding server derives its own defaults.
+                option.model_copy(update={"isDefault": False})
+                for option in field.options or []
+                if str(option.value) in {
+                    "gpt-5.5",
+                    "gpt-5.4",
+                    "gpt-5.4-mini",
+                    "gpt-5.3-codex",
+                    "gpt-5.2",
+                }
+            ]
+        elif field.key == "effort":
+            field.options = [
+                option.model_copy(update={"isDefault": False})
+                for option in field.options or []
+                if str(option.value) in {"low", "medium", "high", "xhigh"}
+            ]
+    return result
+
+
+ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS = _rollback_safe_runtime_config_schemas()
+
+
+def is_rollback_safe_codex_schema(schema: RuntimeConfigSchema) -> bool:
+    return _schema_builtin_signature(schema) == _schema_builtin_signature(
+        ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS["codex"]
+    )
+
+
+def is_current_builtin_codex_schema(schema: RuntimeConfigSchema) -> bool:
+    return _schema_builtin_signature(schema) == _schema_builtin_signature(
+        DEFAULT_RUNTIME_CONFIG_SCHEMAS["codex"]
+    )
+
+
+def _schema_builtin_signature(schema: RuntimeConfigSchema) -> tuple[Any, ...]:
+    def option_signature(option: RuntimeConfigOption) -> tuple[Any, ...]:
+        return (
+            option.value,
+            option.label,
+            option.description,
+            option.isDefault,
+            None
+            if option.efforts is None
+            else tuple(option_signature(effort) for effort in option.efforts),
+        )
+
+    def field_signature(field: RuntimeConfigField) -> tuple[Any, ...]:
+        return (
+            field.key,
+            field.label,
+            field.type,
+            field.description,
+            field.runtimeOptionsSource,
+            json.dumps(field.visibleWhen, sort_keys=True, separators=(",", ":"))
+            if field.visibleWhen is not None
+            else None,
+            field.allowSessionOverride,
+            field.hidden,
+            None
+            if field.options is None
+            else tuple(option_signature(option) for option in field.options),
+            None
+            if field.fields is None
+            else tuple(field_signature(child) for child in field.fields),
+        )
+
+    return (
+        schema.runtime,
+        schema.schemaVersion,
+        tuple(field_signature(field) for field in schema.fields),
+    )
 
 CLAUDE_NO_EFFORT_MODEL = "claude-haiku-4-5"
 _CLAUDE_OPUS_48_47_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
@@ -355,6 +455,38 @@ def default_runtime_settings(runtime: str) -> dict[str, Any]:
         # ACP / unknown agents: empty defaults (no model/permission schema yet).
         return {}
     return deepcopy(settings)
+
+
+def inherited_runtime_setting_keys(runtime: str, persisted: Any) -> set[str]:
+    """Return Codex settings that still inherit the server default.
+
+    A durable ``null`` means "use this server's default", rather than
+    pinning a newly introduced model into a row read by an older server.  The
+    caller supplies the persisted/raw value so an explicit user selection is
+    never mistaken for inheritance.
+    """
+    if runtime != "codex":
+        return set()
+    raw = persisted if isinstance(persisted, dict) else {}
+    return {key for key in ("model", "effort") if raw.get(key) is None}
+
+
+def rollback_safe_inherited_runtime_settings(
+    runtime: str,
+    settings: dict[str, Any],
+    *,
+    inherited_keys: set[str],
+) -> dict[str, Any]:
+    """Persist inherited Codex model/effort as ``null`` values.
+
+    This is intentionally provenance-driven, not value-driven: an explicit
+    choice of the current default (for example Sol / Medium) remains durable.
+    """
+    result = deepcopy(settings)
+    if runtime == "codex":
+        for key in inherited_keys & {"model", "effort"}:
+            result[key] = None
+    return result
 
 
 def normalize_runtime_settings(runtime: str, settings: dict[str, Any]) -> dict[str, Any]:
@@ -513,13 +645,16 @@ def merge_schema_with_agent_options(
 
     if models:
         model_field = next((field for field in result.fields if field.key == "model"), None)
+        static_options = {
+            str(option.value): option
+            for option in (model_field.options if model_field is not None else []) or []
+        }
         options = [
-            RuntimeConfigOption(
-                value=str(item.get("value")),
-                label=str(item.get("label") or item.get("name") or item.get("value")),
-            )
+            option
             for item in models
-            if item.get("value") is not None
+            if isinstance(item, dict)
+            for option in [_runtime_option_from_agent_option(item, static_options)]
+            if option is not None
         ]
         if model_field is None and options:
             result.fields.append(
@@ -540,9 +675,10 @@ def merge_schema_with_agent_options(
             RuntimeConfigOption(
                 value=str(item.get("value")),
                 label=str(item.get("label") or item.get("name") or item.get("value")),
+                isDefault=bool(item.get("isDefault", False)),
             )
             for item in modes
-            if item.get("value") is not None
+            if isinstance(item, dict) and item.get("value") is not None
         ]
         if mode_field is None and options:
             result.fields.append(
@@ -560,6 +696,82 @@ def merge_schema_with_agent_options(
     return result
 
 
+def _runtime_option_from_agent_option(
+    item: dict[str, Any],
+    static_options: dict[str, RuntimeConfigOption],
+) -> RuntimeConfigOption | None:
+    """Normalize a device-discovered model while retaining static constraints.
+
+    Codex emits `model` / `displayName` / `supportedReasoningEfforts`; ACP
+    adapters historically emit `value` / `label`.  A live entry that omits
+    nested efforts is not an assertion that effort is unsupported: retain the
+    matching static option, or leave it as None so the global effort field is
+    used.  An explicit empty array is the only "no effort" signal.
+    """
+    value = item.get("value")
+    if value is None:
+        value = item.get("model")
+    if value is None:
+        value = item.get("id")
+    if not isinstance(value, (str, bool)) or value == "":
+        return None
+    if item.get("hidden") is True:
+        return None
+    key = str(value)
+    static = static_options.get(key)
+    label = item.get("label") or item.get("displayName") or item.get("name") or key
+    raw_efforts = item.get("supportedReasoningEfforts")
+    if raw_efforts is None and "efforts" in item:
+        raw_efforts = item.get("efforts")
+    efforts = _runtime_effort_options(
+        raw_efforts,
+        default=item.get("defaultReasoningEffort"),
+    )
+    if raw_efforts is None and static is not None:
+        efforts = deepcopy(static.efforts)
+    return RuntimeConfigOption(
+        value=value,
+        label=str(label),
+        description=(
+            item.get("description")
+            if isinstance(item.get("description"), str)
+            else (static.description if static is not None else None)
+        ),
+        isDefault=bool(item.get("isDefault", static.isDefault if static is not None else False)),
+        efforts=efforts,
+    )
+
+
+def _runtime_effort_options(raw: Any, *, default: Any) -> list[RuntimeConfigOption] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        # A malformed live constraint must not be reinterpreted as an explicit
+        # empty list (which would silently disable a valid setting).
+        return None
+    default_key = default if isinstance(default, str) else None
+    result: list[RuntimeConfigOption] = []
+    seen: set[str] = set()
+    for item in raw:
+        if isinstance(item, str):
+            value = item
+            label = item.replace("xhigh", "Extra high").replace("_", " ").title()
+            is_default = value == default_key
+        elif isinstance(item, dict):
+            value = item.get("value") or item.get("effort") or item.get("key")
+            if not isinstance(value, str) or not value:
+                continue
+            label = item.get("label") or item.get("displayName") or item.get("name") or value
+            is_default = bool(item.get("isDefault", value == default_key))
+        else:
+            continue
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(RuntimeConfigOption(value=value, label=str(label), isDefault=is_default))
+    return result
+
+
 def _options_from_acp_config(
     config_options: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -573,6 +785,7 @@ def _options_from_acp_config(
         values = opt.get("options") if isinstance(opt.get("options"), list) else []
         parsed = [
             {
+                **entry,
                 "value": str(entry.get("value")),
                 "label": str(entry.get("name") or entry.get("label") or entry.get("value")),
             }
@@ -632,7 +845,7 @@ def _normalize_model_effort_from_schema(
         if "model" in explicit_keys:
             raise ValueError(f"model has unsupported value: {model}")
         if model_options:
-            model = model_options[0].value
+            model = _default_schema_model(model_options)
             result["model"] = model
     allowed = _schema_efforts_for_model(model_field, effort_field, model)
     if allowed is None:
@@ -646,14 +859,19 @@ def _normalize_model_effort_from_schema(
         if "effort" in explicit_keys:
             raise ValueError(f"effort {effort} is not supported by {model}")
         result["effort"] = (
-            _first_schema_effort_for_model(model_field, model)
+            _default_schema_effort_for_model(model_field, model)
             if schema.runtime == "codex"
             else None
         )
     return result
 
 
-def _first_schema_effort_for_model(
+def _default_schema_model(model_options: list[RuntimeConfigOption]) -> str | bool:
+    selected = next((option for option in model_options if option.isDefault), model_options[0])
+    return selected.value
+
+
+def _default_schema_effort_for_model(
     model_field: RuntimeConfigField,
     model: Any,
 ) -> str | None:
@@ -665,9 +883,10 @@ def _first_schema_effort_for_model(
         ),
         None,
     )
-    if selected is None or not selected.efforts:
+    if selected is None or selected.efforts is None or not selected.efforts:
         return None
-    return str(selected.efforts[0].value)
+    effort = next((option for option in selected.efforts if option.isDefault), selected.efforts[0])
+    return str(effort.value)
 
 
 def _schema_efforts_for_model(
@@ -683,11 +902,13 @@ def _schema_efforts_for_model(
                 for option in model_options
                 if isinstance(model, str) and model and option.value == model
             ),
-            model_options[0] if not isinstance(model, str) or not model else None,
+            _default_schema_option(model_options) if not isinstance(model, str) or not model else None,
         )
         if selected is None:
             return None
-        return {str(effort.value) for effort in (selected.efforts or [])}
+        if selected.efforts is None:
+            return {str(option.value) for option in (effort_field.options or [])}
+        return {str(effort.value) for effort in selected.efforts}
     if isinstance(model, str) and model:
         for option in model_options:
             if option.value == model:
@@ -696,6 +917,12 @@ def _schema_efforts_for_model(
     if effort_field.options:
         return {str(option.value) for option in effort_field.options}
     return None
+
+
+def _default_schema_option(options: list[RuntimeConfigOption]) -> RuntimeConfigOption | None:
+    if not options:
+        return None
+    return next((option for option in options if option.isDefault), options[0])
 
 
 def _attach_default_model_efforts(schema: RuntimeConfigSchema) -> None:
@@ -737,6 +964,7 @@ def _catalog_entry_to_option(entry: Any, *, include_efforts: bool) -> RuntimeCon
         value=key,
         label=label,
         description=description if isinstance(description, str) else None,
+        isDefault=bool(_entry_value(entry, "isDefault")),
         efforts=[
             _catalog_entry_to_option(effort, include_efforts=False)
             for effort in (efforts if include_efforts and isinstance(efforts, list) else [])
@@ -751,6 +979,11 @@ def _aggregate_effort_options(model_options: list[RuntimeConfigOption]) -> list[
         for effort in model.efforts or []:
             key = str(effort.value)
             if key in seen:
+                if effort.isDefault:
+                    result = [
+                        item.model_copy(update={"isDefault": True}) if str(item.value) == key else item
+                        for item in result
+                    ]
                 continue
             seen.add(key)
             result.append(effort.model_copy(update={"efforts": None}))

--- a/server/agent_server/infra/repositories/agent_catalog.py
+++ b/server/agent_server/infra/repositories/agent_catalog.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import json
+
 from agent_server.infra.repositories.store_support import *
 from agent_server.core.runtime_config import (
     DEFAULT_RUNTIME_CONFIG_SCHEMAS,
+    ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS,
+    PersistedRuntimeConfigError,
     claude_efforts_for_model,
     codex_efforts_for_model,
+    inherited_runtime_setting_keys,
+    merge_settings,
+    rollback_safe_inherited_runtime_settings,
 )
 
 
@@ -24,18 +31,7 @@ class AgentCatalogRepositoryMixin:
         if not rows:
             return
         async with self._engine.begin() as conn:
-            existing = (
-                await conn.execute(
-                    select(table.c.runtime, table.c.key).where(
-                        table.c.runtime.in_({row["runtime"] for row in rows})
-                    )
-                )
-            ).all()
-            present = {(r.runtime, r.key) for r in existing}
-            missing = [row for row in rows if (row["runtime"], row["key"]) not in present]
-            if not missing:
-                return
-            await conn.execute(insert(table), missing)
+            await conn.execute(_seed_insert_statement(conn, table, rows))
 
     # --- runtime config schema / settings ------------------------------------
 
@@ -113,6 +109,11 @@ class AgentCatalogRepositoryMixin:
                     raise ValueError(f"unsupported runtime: {runtime}")
                 if not isinstance(raw_update, dict):
                     raise ValueError(f"{runtime} must be an object")
+                # An empty runtime object is intentionally a no-op.  In
+                # particular, do not materialize the current global catalog
+                # into models_json merely because a client PATCHed `{}`.
+                if "models" not in raw_update:
+                    continue
                 current = await self._get_user_agent_default_runtime_on_conn(
                     conn,
                     user_id,
@@ -120,9 +121,7 @@ class AgentCatalogRepositoryMixin:
                 )
                 enabled = bool(current["enabled"])
                 settings = current["settings"]
-                models = current["models"]
-                if "models" in raw_update and raw_update["models"] is not None:
-                    models = _normalize_model_catalog_entries(runtime, raw_update["models"])
+                models = _normalize_model_catalog_entries(runtime, raw_update["models"])
                 await self._upsert_user_agent_default_on_conn(
                     conn,
                     user_id=user_id,
@@ -130,6 +129,7 @@ class AgentCatalogRepositoryMixin:
                     enabled=enabled,
                     settings=settings,
                     models=models,
+                    inherited_settings_keys=current["_inheritedSettingsKeys"],
                     updated_at=now,
                 )
         return await self.get_user_agent_defaults(user_id)
@@ -141,20 +141,28 @@ class AgentCatalogRepositoryMixin:
         user_id: str,
         connector_id: str,
     ) -> None:
-        defaults = await self.get_user_agent_defaults(user_id)
         now = utc_now()
         async with self._engine.begin() as conn:
-            for runtime, item in defaults.items():
+            for runtime in SUPPORTED_DEFAULT_AGENT_RUNTIMES:
+                item = await self._get_user_agent_default_runtime_on_conn(conn, user_id, runtime)
                 settings = item["settings"]
                 schema = DEFAULT_RUNTIME_CONFIG_SCHEMAS.get(runtime)
                 if schema is None:
                     continue
+                durable_settings = rollback_safe_inherited_runtime_settings(
+                    runtime,
+                    settings,
+                    inherited_keys=item["_inheritedSettingsKeys"],
+                )
+                schema_version = schema.schemaVersion
+                if runtime == "codex" and item["_inheritedSettingsKeys"] == {"model", "effort"}:
+                    schema_version = ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS["codex"].schemaVersion
                 await conn.execute(
                     insert(device_agent_settings_t).values(
                         connector_id=connector_id,
                         runtime=runtime,
-                        settings_json=_json_dumps(settings),
-                        schema_version=schema.schemaVersion,
+                        settings_json=_json_dumps(durable_settings),
+                        schema_version=schema_version,
                         updated_at=now,
                     )
                 )
@@ -185,7 +193,8 @@ class AgentCatalogRepositoryMixin:
         ).mappings().first()
         if row is not None:
             enabled = bool(row["enabled"])
-            settings = _json_loads(row["settings_json"]) or {}
+            stored_settings = _json_loads(row["settings_json"]) or {}
+            settings = _project_user_default_settings(runtime, stored_settings)
             # Read exact legacy built-in snapshots through the current global
             # catalog without rewriting them, so a server rollback stays safe.
             models = (
@@ -196,7 +205,8 @@ class AgentCatalogRepositoryMixin:
             )
         else:
             enabled = True
-            settings = default_agent_settings(runtime)
+            stored_settings = {}
+            settings = _project_user_default_settings(runtime, stored_settings)
             models = []
         if not models:
             models = await self._list_agent_catalog_on_conn(conn, agent_models_t, runtime)
@@ -205,12 +215,21 @@ class AgentCatalogRepositoryMixin:
                 models = _default_catalog_from_runtime_schema(runtime, "model")
             if not efforts:
                 efforts = _default_catalog_from_runtime_schema(runtime, "effort")
+            if runtime == "codex" and _is_rollback_safe_codex_catalog(models, efforts):
+                # Catalog persistence remains readable by the preceding
+                # server; GPT-5.6 is projected only while the new server is
+                # serving this exact built-in baseline.
+                models = _default_catalog_from_runtime_schema(runtime, "model")
+                efforts = _default_catalog_from_runtime_schema(runtime, "effort")
             models = _models_with_default_efforts(runtime, models, efforts)
         return {
             "runtime": runtime,
             "enabled": enabled,
             "settings": settings,
             "models": models,
+            # Private provenance used only while applying/updating defaults.
+            # API response builders copy the public fields explicitly.
+            "_inheritedSettingsKeys": inherited_runtime_setting_keys(runtime, stored_settings),
         }
 
 
@@ -249,13 +268,19 @@ class AgentCatalogRepositoryMixin:
         enabled: bool,
         settings: dict[str, Any],
         models: list[AgentCatalogEntry],
+        inherited_settings_keys: set[str],
         updated_at: str,
     ) -> None:
+        durable_settings = rollback_safe_inherited_runtime_settings(
+            runtime,
+            settings,
+            inherited_keys=inherited_settings_keys,
+        )
         values = {
             "user_id": user_id,
             "runtime": runtime,
             "enabled": 1 if enabled else 0,
-            "settings_json": _json_dumps(settings),
+            "settings_json": _json_dumps(durable_settings),
             "models_json": _json_dumps([entry.model_dump() for entry in models]),
             "updated_at": updated_at,
         }
@@ -280,10 +305,23 @@ class AgentCatalogRepositoryMixin:
             )
 
 
+def _project_user_default_settings(runtime: str, stored: Any) -> dict[str, Any]:
+    """Project nullable durable defaults through this server's defaults."""
+    persisted = stored if isinstance(stored, dict) else {}
+    return merge_settings(default_agent_settings(runtime), persisted)
+
+
 def _catalog_entries_from_json(runtime: str, raw: str | None) -> list[AgentCatalogEntry]:
-    data = _json_loads(raw)
-    if not isinstance(data, list):
+    if raw is None:
         return []
+    try:
+        data = _json_loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise PersistedRuntimeConfigError(f"invalid persisted {runtime} models_json") from exc
+    if not isinstance(data, list):
+        raise PersistedRuntimeConfigError(
+            f"invalid persisted {runtime} models_json: expected a list"
+        )
     return _normalize_model_catalog_entries(runtime, data)
 
 
@@ -362,17 +400,19 @@ def _default_catalog_from_runtime_schema(runtime: str, field_key: str) -> list[A
     for field in schema.fields:
         if field.key != field_key:
             continue
+        options = field.options or []
+        has_default = any(option.isDefault for option in options)
         return [
             AgentCatalogEntry(
                 runtime=runtime,
                 key=str(option.value),
                 displayLabel=option.label,
                 description=option.description,
-                isDefault=index == 0,
+                isDefault=option.isDefault if has_default else index == 0,
                 sortOrder=index + 1,
                 efforts=[],
             )
-            for index, option in enumerate(field.options or [])
+            for index, option in enumerate(options)
             if isinstance(option.value, str)
         ]
     return []
@@ -389,6 +429,45 @@ def _models_with_default_efforts(
         )
         for model in models
     ]
+
+
+def _is_rollback_safe_codex_catalog(
+    models: list[AgentCatalogEntry],
+    efforts: list[AgentCatalogEntry],
+) -> bool:
+    return (
+        _catalog_entry_rows_signature(models) == _seed_rows_signature(SEED_AGENT_MODELS, "codex")
+        and _catalog_entry_rows_signature(efforts) == _seed_rows_signature(SEED_AGENT_EFFORTS, "codex")
+    )
+
+
+def _catalog_entry_rows_signature(entries: list[AgentCatalogEntry]) -> tuple[tuple[str, str, str, int, bool], ...]:
+    return tuple(
+        (
+            entry.key,
+            entry.displayLabel,
+            entry.description or "",
+            entry.sortOrder,
+            entry.isDefault,
+        )
+        for entry in entries
+    )
+
+
+def _seed_rows_signature(
+    rows: list[dict[str, Any]], runtime: str
+) -> tuple[tuple[str, str, str, int, bool], ...]:
+    return tuple(
+        (
+            str(row["key"]),
+            str(row["display_label"]),
+            str(row.get("description") or ""),
+            int(row["sort_order"]),
+            bool(row["is_default"]),
+        )
+        for row in rows
+        if row["runtime"] == runtime
+    )
 
 
 def _default_efforts_for_model(

--- a/server/agent_server/infra/repositories/runtime_config_facade.py
+++ b/server/agent_server/infra/repositories/runtime_config_facade.py
@@ -116,6 +116,40 @@ class RuntimeConfigRepositoryMixin:
         )
 
 
+    async def get_durable_initial_runtime_settings_for_connector_agent(
+        self,
+        connector_id: str,
+        runtime: str,
+        *,
+        user_id: str | None = None,
+        patch: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await self.runtime_config.get_durable_initial_runtime_settings_for_connector_agent(
+            connector_id,
+            runtime,
+            user_id=user_id,
+            patch=patch,
+        )
+
+
+    async def get_initial_runtime_settings_bundle(
+        self,
+        connector_id: str,
+        runtime: str,
+        *,
+        user_id: str | None = None,
+        cwd: str | None = None,
+        patch: dict[str, Any] | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        return await self.runtime_config.get_initial_runtime_settings_bundle(
+            connector_id,
+            runtime,
+            user_id=user_id,
+            cwd=cwd,
+            patch=patch,
+        )
+
+
     async def serialize_initial_settings_for_connector_agent(
         self,
         connector_id: str,

--- a/server/agent_server/infra/repositories/sessions.py
+++ b/server/agent_server/infra/repositories/sessions.py
@@ -31,7 +31,7 @@ class SessionRepositoryMixin:
             if connector is None:
                 raise KeyError(connector_id)
             if runtime_settings_override is None and runtime in {"codex", "claude"}:
-                runtime_settings_override = await self.get_initial_runtime_settings_for_connector_agent(
+                runtime_settings_override = await self.get_durable_initial_runtime_settings_for_connector_agent(
                     connector_id,
                     runtime,
                     user_id=user_id,
@@ -109,7 +109,7 @@ class SessionRepositoryMixin:
                     session_id = existing.id
             if existing is None:
                 if runtime_settings_override is None and runtime in {"codex", "claude"}:
-                    runtime_settings_override = await self.get_initial_runtime_settings_for_connector_agent(
+                    runtime_settings_override = await self.get_durable_initial_runtime_settings_for_connector_agent(
                         connector_id,
                         runtime,
                     )
@@ -721,6 +721,11 @@ class SessionRepositoryMixin:
             runtime_settings = await self.get_effective_runtime_settings(session_id)
         except (KeyError, ValueError):
             runtime_settings = None
+        runtime_override_view = (
+            runtime_settings
+            if runtime == "codex" and runtime_override and runtime_settings is not None
+            else runtime_override
+        )
         title = row["title"]
         if not (isinstance(title, str) and title.strip()):
             derived = await self._derive_title_from_first_user_message(session_id)
@@ -755,5 +760,5 @@ class SessionRepositoryMixin:
             sortAt=sort_at,
             updatedSeq=updated_seq,
             runtimeSettings=runtime_settings,
-            runtimeSettingsOverride=runtime_override or None,
+            runtimeSettingsOverride=runtime_override_view or None,
         )

--- a/server/agent_server/infra/repositories/store_support.py
+++ b/server/agent_server/infra/repositories/store_support.py
@@ -14,6 +14,8 @@ from typing import Any, AsyncIterator
 
 from loguru import logger
 from sqlalchemy import create_engine, delete, func, insert, select, text, update
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 
@@ -573,35 +575,11 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
     },
     {
         "runtime": "codex",
-        "key": "gpt-5.6-sol",
-        "display_label": "GPT-5.6-Sol",
-        "description": None,
-        "is_default": 1,
-        "sort_order": 1,
-    },
-    {
-        "runtime": "codex",
-        "key": "gpt-5.6-terra",
-        "display_label": "GPT-5.6-Terra",
-        "description": None,
-        "is_default": 0,
-        "sort_order": 2,
-    },
-    {
-        "runtime": "codex",
-        "key": "gpt-5.6-luna",
-        "display_label": "GPT-5.6-Luna",
-        "description": None,
-        "is_default": 0,
-        "sort_order": 3,
-    },
-    {
-        "runtime": "codex",
         "key": "gpt-5.5",
         "display_label": "GPT-5.5",
         "description": None,
-        "is_default": 0,
-        "sort_order": 4,
+        "is_default": 1,
+        "sort_order": 1,
     },
     {
         "runtime": "codex",
@@ -609,7 +587,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.4",
         "description": None,
         "is_default": 0,
-        "sort_order": 5,
+        "sort_order": 2,
     },
     {
         "runtime": "codex",
@@ -617,7 +595,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.4 Mini",
         "description": None,
         "is_default": 0,
-        "sort_order": 6,
+        "sort_order": 3,
     },
     {
         "runtime": "codex",
@@ -625,7 +603,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.3 Codex",
         "description": None,
         "is_default": 0,
-        "sort_order": 7,
+        "sort_order": 4,
     },
     {
         "runtime": "codex",
@@ -633,7 +611,7 @@ SEED_AGENT_MODELS: list[dict[str, Any]] = [
         "display_label": "GPT-5.2",
         "description": None,
         "is_default": 0,
-        "sort_order": 8,
+        "sort_order": 5,
     },
 ]
 
@@ -666,15 +644,23 @@ def _seed_agent_catalog_sync(async_url: str) -> None:
 def _seed_table_sync(conn: Any, table: Any, rows: list[dict[str, Any]]) -> None:
     if not rows:
         return
-    existing = conn.execute(
-        select(table.c.runtime, table.c.key).where(
-            table.c.runtime.in_({row["runtime"] for row in rows})
+    conn.execute(_seed_insert_statement(conn, table, rows))
+
+
+def _seed_insert_statement(conn: Any, table: Any, rows: list[dict[str, Any]]) -> Any:
+    """Build an atomic catalog insert for both supported SQL dialects."""
+    dialect = conn.dialect.name
+    if dialect == "sqlite":
+        return sqlite_insert(table).values(rows).on_conflict_do_nothing(
+            index_elements=["runtime", "key"]
         )
-    ).all()
-    present = {(row.runtime, row.key) for row in existing}
-    missing = [row for row in rows if (row["runtime"], row["key"]) not in present]
-    if missing:
-        conn.execute(insert(table), missing)
+    if dialect == "postgresql":
+        return postgresql_insert(table).values(rows).on_conflict_do_nothing(
+            index_elements=["runtime", "key"]
+        )
+    # The production backends are SQLite and Postgres. Preserve a conservative
+    # fallback for downstream test adapters instead of pretending it is safe.
+    return insert(table).values(rows)
 
 
 def _seed_agent_catalog_async_in_thread(async_url: str) -> None:
@@ -689,17 +675,7 @@ def _seed_agent_catalog_async_in_thread(async_url: str) -> None:
                 for table, rows in _CATALOG_SEED_PLAN:
                     if not rows:
                         continue
-                    existing = (
-                        await conn.execute(
-                            select(table.c.runtime, table.c.key).where(
-                                table.c.runtime.in_({row["runtime"] for row in rows})
-                            )
-                        )
-                    ).all()
-                    present = {(row.runtime, row.key) for row in existing}
-                    missing = [row for row in rows if (row["runtime"], row["key"]) not in present]
-                    if missing:
-                        await conn.execute(insert(table), missing)
+                    await conn.execute(_seed_insert_statement(conn, table, rows))
                 await _migrate_codex_catalog_async(conn)
         finally:
             await engine.dispose()
@@ -771,7 +747,7 @@ SEED_AGENT_EFFORTS: list[dict[str, Any]] = [
         "key": "medium",
         "display_label": "Medium",
         "description": None,
-        "is_default": 1,
+        "is_default": 0,
         "sort_order": 2,
     },
     {
@@ -787,24 +763,8 @@ SEED_AGENT_EFFORTS: list[dict[str, Any]] = [
         "key": "xhigh",
         "display_label": "Extra high",
         "description": None,
-        "is_default": 0,
+        "is_default": 1,
         "sort_order": 4,
-    },
-    {
-        "runtime": "codex",
-        "key": "max",
-        "display_label": "Max",
-        "description": None,
-        "is_default": 0,
-        "sort_order": 5,
-    },
-    {
-        "runtime": "codex",
-        "key": "ultra",
-        "display_label": "Ultra",
-        "description": None,
-        "is_default": 0,
-        "sort_order": 6,
     },
 ]
 
@@ -829,30 +789,101 @@ _LEGACY_CODEX_EFFORT_SIGNATURE = (
     ("xhigh", "Extra high", "", 4),
 )
 
+_CURRENT_CODEX_MODEL_SIGNATURE = (
+    ("gpt-5.6-sol", "GPT-5.6-Sol", "", 1, True),
+    ("gpt-5.6-terra", "GPT-5.6-Terra", "", 2, False),
+    ("gpt-5.6-luna", "GPT-5.6-Luna", "", 3, False),
+    ("gpt-5.5", "GPT-5.5", "", 4, False),
+    ("gpt-5.4", "GPT-5.4", "", 5, False),
+    ("gpt-5.4-mini", "GPT-5.4 Mini", "", 6, False),
+    ("gpt-5.3-codex", "GPT-5.3 Codex", "", 7, False),
+    ("gpt-5.2", "GPT-5.2", "", 8, False),
+)
+_CURRENT_CODEX_EFFORT_SIGNATURE = (
+    ("low", "Low", "", 1, False),
+    ("medium", "Medium", "", 2, True),
+    ("high", "High", "", 3, False),
+    ("xhigh", "Extra high", "", 4, False),
+    ("max", "Max", "", 5, False),
+    ("ultra", "Ultra", "", 6, False),
+)
+
 
 def _migrate_codex_catalog_sync(conn: Any) -> None:
-    for statement in _codex_catalog_metadata_updates():
-        conn.execute(statement)
+    models = _catalog_table_signature_sync(conn, agent_models_t)
+    efforts = _catalog_table_signature_sync(conn, agent_efforts_t)
+    if models == _CURRENT_CODEX_MODEL_SIGNATURE and efforts == _CURRENT_CODEX_EFFORT_SIGNATURE:
+        _converge_current_codex_catalog_sync(conn)
+    _converge_current_codex_default_snapshots_sync(conn)
 
 
 async def _migrate_codex_catalog_async(conn: AsyncConnection) -> None:
-    for statement in _codex_catalog_metadata_updates():
+    models = await _catalog_table_signature_async(conn, agent_models_t)
+    efforts = await _catalog_table_signature_async(conn, agent_efforts_t)
+    if models == _CURRENT_CODEX_MODEL_SIGNATURE and efforts == _CURRENT_CODEX_EFFORT_SIGNATURE:
+        await _converge_current_codex_catalog_async(conn)
+    await _converge_current_codex_default_snapshots_async(conn)
+
+
+def _catalog_table_signature_sync(conn: Any, table: Any) -> tuple[tuple[str, str, str, int, bool], ...]:
+    rows = conn.execute(
+        select(table)
+        .where(table.c.runtime == "codex")
+        .order_by(table.c.sort_order.asc(), table.c.key.asc())
+    ).mappings().all()
+    return _catalog_rows_signature(rows)
+
+
+async def _catalog_table_signature_async(
+    conn: AsyncConnection, table: Any
+) -> tuple[tuple[str, str, str, int, bool], ...]:
+    rows = (
+        await conn.execute(
+            select(table)
+            .where(table.c.runtime == "codex")
+            .order_by(table.c.sort_order.asc(), table.c.key.asc())
+        )
+    ).mappings().all()
+    return _catalog_rows_signature(rows)
+
+
+def _catalog_rows_signature(rows: Any) -> tuple[tuple[str, str, str, int, bool], ...]:
+    return tuple(
+        (
+            str(row["key"]),
+            str(row["display_label"]),
+            str(row["description"] or ""),
+            int(row["sort_order"]),
+            bool(row["is_default"]),
+        )
+        for row in rows
+    )
+
+
+def _converge_current_codex_catalog_sync(conn: Any) -> None:
+    for statement in _rollback_safe_codex_catalog_updates():
+        conn.execute(statement)
+
+
+async def _converge_current_codex_catalog_async(conn: AsyncConnection) -> None:
+    for statement in _rollback_safe_codex_catalog_updates():
         await conn.execute(statement)
 
 
-def _codex_catalog_metadata_updates() -> list[Any]:
+def _rollback_safe_codex_catalog_updates() -> list[Any]:
     statements: list[Any] = [
-        update(agent_models_t)
-        .where(agent_models_t.c.runtime == "codex")
-        .values(is_default=0),
-        update(agent_efforts_t)
-        .where(agent_efforts_t.c.runtime == "codex")
-        .values(is_default=0),
+        delete(agent_models_t).where(
+            agent_models_t.c.runtime == "codex",
+            agent_models_t.c.key.in_({"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}),
+        ),
+        delete(agent_efforts_t).where(
+            agent_efforts_t.c.runtime == "codex",
+            agent_efforts_t.c.key.in_({"max", "ultra"}),
+        ),
+        update(agent_models_t).where(agent_models_t.c.runtime == "codex").values(is_default=0),
+        update(agent_efforts_t).where(agent_efforts_t.c.runtime == "codex").values(is_default=0),
     ]
-    for table, rows in (
-        (agent_models_t, SEED_AGENT_MODELS),
-        (agent_efforts_t, SEED_AGENT_EFFORTS),
-    ):
+    for table, rows in ((agent_models_t, SEED_AGENT_MODELS), (agent_efforts_t, SEED_AGENT_EFFORTS)):
         for row in rows:
             if row["runtime"] != "codex":
                 continue
@@ -862,6 +893,85 @@ def _codex_catalog_metadata_updates() -> list[Any]:
                 .values(is_default=row["is_default"], sort_order=row["sort_order"])
             )
     return statements
+
+
+def _converge_current_codex_default_snapshots_sync(conn: Any) -> None:
+    rows = conn.execute(
+        select(user_agent_defaults_t.c.user_id, user_agent_defaults_t.c.models_json).where(
+            user_agent_defaults_t.c.runtime == "codex"
+        )
+    ).mappings().all()
+    for row in rows:
+        if _is_current_builtin_codex_models_json(row["models_json"]):
+            conn.execute(
+                update(user_agent_defaults_t)
+                .where(
+                    user_agent_defaults_t.c.user_id == row["user_id"],
+                    user_agent_defaults_t.c.runtime == "codex",
+                )
+                .values(models_json=_json_dumps(_legacy_builtin_codex_models_payload()), updated_at=utc_now())
+            )
+
+
+async def _converge_current_codex_default_snapshots_async(conn: AsyncConnection) -> None:
+    rows = (
+        await conn.execute(
+            select(user_agent_defaults_t.c.user_id, user_agent_defaults_t.c.models_json).where(
+                user_agent_defaults_t.c.runtime == "codex"
+            )
+        )
+    ).mappings().all()
+    for row in rows:
+        if _is_current_builtin_codex_models_json(row["models_json"]):
+            await conn.execute(
+                update(user_agent_defaults_t)
+                .where(
+                    user_agent_defaults_t.c.user_id == row["user_id"],
+                    user_agent_defaults_t.c.runtime == "codex",
+                )
+                .values(models_json=_json_dumps(_legacy_builtin_codex_models_payload()), updated_at=utc_now())
+            )
+
+
+def _legacy_builtin_codex_models_payload() -> list[dict[str, Any]]:
+    return [
+        {
+            "key": key,
+            "displayLabel": label,
+            "sortOrder": sort_order,
+            "efforts": [
+                {
+                    "key": effort_key,
+                    "displayLabel": effort_label,
+                    "sortOrder": effort_order,
+                }
+                for effort_key, effort_label, _description, effort_order in _LEGACY_CODEX_EFFORT_SIGNATURE
+            ],
+        }
+        for key, label, _description, sort_order in _LEGACY_CODEX_MODEL_SIGNATURE
+    ]
+
+
+def _is_current_builtin_codex_models_json(raw: str | None) -> bool:
+    try:
+        models = _json_loads(raw)
+    except Exception:
+        return False
+    if not isinstance(models, list) or len(models) != len(_CURRENT_CODEX_MODEL_SIGNATURE):
+        return False
+    for model, expected in zip(models, _CURRENT_CODEX_MODEL_SIGNATURE, strict=True):
+        if not isinstance(model, dict) or _catalog_item_signature(model) != expected[:4]:
+            return False
+        efforts = model.get("efforts")
+        if not isinstance(efforts, list) or tuple(
+            _catalog_item_signature(effort)
+            for effort in efforts
+            if isinstance(effort, dict)
+        ) != tuple(item[:4] for item in _CURRENT_CODEX_EFFORT_SIGNATURE):
+            return False
+        if any(not isinstance(effort, dict) for effort in efforts):
+            return False
+    return True
 
 
 def _is_legacy_builtin_codex_models_json(raw: str | None) -> bool:
@@ -895,6 +1005,8 @@ def _catalog_item_signature(item: dict[str, Any]) -> tuple[str, str, str, int] |
         str(item.get("description") or ""),
         sort_order,
     )
+
+
 
 
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/server/agent_server/services/runtime_config.py
+++ b/server/agent_server/services/runtime_config.py
@@ -3,24 +3,33 @@ from __future__ import annotations
 import json
 import asyncio
 import threading
+from copy import deepcopy
 from typing import Any
 
 from sqlalchemy import create_engine, insert, select, update
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from agent_server.infra.db import instance_settings as instance_settings_t
 from agent_server.infra.repositories import InstanceSettingsRepository, RuntimeSettingsRepository
 from agent_server.core.runtime_config import (
     DEFAULT_RUNTIME_CONFIG_SCHEMAS,
+    ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS,
+    PersistedRuntimeConfigError,
     RuntimeConfigSchema,
     apply_settings_patch,
     default_runtime_settings,
     filter_runtime_settings,
+    inherited_runtime_setting_keys,
     merge_settings,
     normalize_runtime_settings,
     normalize_setting_constraints,
+    rollback_safe_inherited_runtime_settings,
     runtime_schema_key,
     schema_with_user_agent_defaults,
+    is_current_builtin_codex_schema,
+    is_rollback_safe_codex_schema,
     validate_runtime_schema,
     validate_runtime_settings,
 )
@@ -35,7 +44,110 @@ def _json_dumps(value: Any) -> str:
 def _json_loads(value: str | None) -> Any:
     if not value:
         return None
-    return json.loads(value)
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise PersistedRuntimeConfigError("invalid persisted runtime config JSON") from exc
+
+
+def _persistent_schema_json(schema: RuntimeConfigSchema) -> str:
+    """Serialize a rollback-safe schema without new-only option metadata."""
+    raw = schema.model_dump(exclude_none=True)
+
+    def strip_option_metadata(value: Any) -> Any:
+        if isinstance(value, list):
+            return [strip_option_metadata(item) for item in value]
+        if isinstance(value, dict):
+            return {
+                key: strip_option_metadata(item)
+                for key, item in value.items()
+                if key != "isDefault"
+            }
+        return value
+
+    return _json_dumps(strip_option_metadata(raw))
+
+
+def _runtime_schema_insert_if_missing(
+    conn: Any,
+    *,
+    key: str,
+    value: str,
+    updated_at: str,
+) -> Any:
+    values = {"key": key, "value": value, "updated_at": updated_at}
+    if conn.dialect.name == "sqlite":
+        return sqlite_insert(instance_settings_t).values(**values).on_conflict_do_nothing(
+            index_elements=["key"]
+        )
+    if conn.dialect.name == "postgresql":
+        return postgresql_insert(instance_settings_t).values(**values).on_conflict_do_nothing(
+            index_elements=["key"]
+        )
+    return insert(instance_settings_t).values(**values)
+
+
+def _inherited_keys_after_patch(
+    runtime: str,
+    persisted: Any,
+    patch: dict[str, Any] | None,
+) -> set[str]:
+    keys = inherited_runtime_setting_keys(runtime, persisted)
+    if runtime != "codex" or not patch:
+        return keys
+    for key in {"model", "effort"} & set(patch):
+        if patch[key] is None:
+            keys.add(key)
+        else:
+            keys.discard(key)
+    return keys
+
+
+def _should_reseed_runtime_schema(
+    runtime: str,
+    existing: str | None,
+    persisted_schema: RuntimeConfigSchema,
+) -> bool:
+    if existing is None:
+        return True
+    try:
+        stored = validate_runtime_schema(runtime, _json_loads(existing))
+    except Exception:
+        # Invalid instance-owned schema remains observable through the read
+        # endpoint; do not silently replace operator data.
+        return False
+    if runtime == "codex":
+        # Only exact built-ins are safe to converge. Any differing v3/v4
+        # schema may be operator customisation and is deliberately preserved.
+        if is_current_builtin_codex_schema(stored):
+            return True
+        if is_rollback_safe_codex_schema(stored):
+            return False
+        if (
+            not stored.fields
+            and stored.schemaVersion
+            in {persisted_schema.schemaVersion, DEFAULT_RUNTIME_CONFIG_SCHEMAS["codex"].schemaVersion}
+        ):
+            return True
+        return _is_empty_builtin_schema(stored, persisted_schema)
+    if stored.schemaVersion < persisted_schema.schemaVersion:
+        return True
+    return _is_empty_builtin_schema(stored, persisted_schema)
+
+
+def _is_empty_builtin_schema(
+    stored: RuntimeConfigSchema,
+    expected: RuntimeConfigSchema,
+) -> bool:
+    # An empty same-version built-in schema is a known interrupted-seed shape.
+    # Do not attempt to infer intent from a non-empty schema: that could erase
+    # a valid operator customisation.
+    return (
+        stored.runtime == expected.runtime
+        and stored.schemaVersion == expected.schemaVersion
+        and not stored.fields
+        and bool(expected.fields)
+    )
 
 
 class RuntimeConfigService:
@@ -53,16 +165,11 @@ class RuntimeConfigService:
         for runtime, schema in DEFAULT_RUNTIME_CONFIG_SCHEMAS.items():
             key = runtime_schema_key(runtime)
             existing = await self._instance_settings.get(key)
-            if existing is None:
+            persisted = ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS.get(runtime, schema)
+            if _should_reseed_runtime_schema(runtime, existing, persisted):
                 await self._instance_settings.set(
                     key,
-                    _json_dumps(schema.model_dump(exclude_none=True)),
-                )
-                continue
-            if _stored_schema_version(existing) < schema.schemaVersion:
-                await self._instance_settings.set(
-                    key,
-                    _json_dumps(schema.model_dump(exclude_none=True)),
+                    _persistent_schema_json(persisted),
                 )
 
     async def get_runtime_config_schema(self, runtime: str) -> RuntimeConfigSchema:
@@ -74,9 +181,17 @@ class RuntimeConfigService:
             raise KeyError(runtime)
         try:
             raw = _json_loads(value)
-            return validate_runtime_schema(runtime, raw)
+            schema = validate_runtime_schema(runtime, raw)
+            if runtime == "codex" and is_rollback_safe_codex_schema(schema):
+                # GPT-5.6 is an in-memory projection over the durable v3
+                # baseline.  Do not write here: a rolled-back server must see
+                # exactly the durable data it expects.
+                return deepcopy(DEFAULT_RUNTIME_CONFIG_SCHEMAS["codex"])
+            return schema
         except Exception as exc:
-            raise ValueError(f"invalid runtime config schema for {runtime}") from exc
+            raise PersistedRuntimeConfigError(
+                f"invalid persisted runtime config schema for {runtime}"
+            ) from exc
 
     async def get_runtime_config_schema_for_user(
         self,
@@ -162,10 +277,22 @@ class RuntimeConfigService:
             schema,
             session_override=False,
         )
-        current = await self.get_device_agent_settings(
-            connector_id,
+        raw_current = _json_loads(
+            await self._runtime_settings.get_device_settings_json(connector_id, runtime)
+        )
+        current_stored = filter_runtime_settings(
+            normalize_runtime_settings(
+                runtime,
+                raw_current if isinstance(raw_current, dict) else {},
+            ),
+            schema,
+            session_override=False,
+        )
+        current = normalize_setting_constraints(
             runtime,
-            user_id=user_id,
+            merge_settings(default_runtime_settings(runtime), current_stored),
+            explicit_keys=set(),
+            schema=schema,
         )
         next_settings = apply_settings_patch(
             current,
@@ -175,11 +302,23 @@ class RuntimeConfigService:
             explicit_keys=set(normalized_patch),
             schema=schema,
         )
+        inherited_keys = _inherited_keys_after_patch(runtime, raw_current, normalized_patch)
+        persisted_settings = rollback_safe_inherited_runtime_settings(
+            runtime,
+            next_settings,
+            inherited_keys=inherited_keys,
+        )
+        # Rows containing only inherited Codex model/effort must keep the
+        # preceding server's schema version too.  A deliberate model/effort
+        # choice keeps the current version and is never rewritten here.
+        schema_version = schema.schemaVersion
+        if runtime == "codex" and inherited_keys == {"model", "effort"}:
+            schema_version = ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS["codex"].schemaVersion
         await self._runtime_settings.upsert_device_settings_json(
             connector_id,
             runtime,
-            settings_json=_json_dumps(next_settings),
-            schema_version=schema.schemaVersion,
+            settings_json=_json_dumps(persisted_settings),
+            schema_version=schema_version,
             updated_at=utc_now(),
         )
         return next_settings
@@ -192,18 +331,27 @@ class RuntimeConfigService:
     ) -> dict[str, Any]:
         row = await self._runtime_settings.get_session_runtime_row(session_id, user_id=user_id)
         runtime = str(row["runtime"])
-        schema = await self.get_runtime_config_schema_for_user(
-            runtime,
-            user_id=user_id or str(row["connector_user_id"]),
+        schema = await self._get_session_runtime_config_schema(
+            row,
+            user_id=user_id,
         )
         value = _json_loads(row["runtime_settings_override"])
-        return filter_runtime_settings(
+        override = filter_runtime_settings(
             normalize_runtime_settings(
                 runtime,
                 value if isinstance(value, dict) else {},
             ),
             schema,
             session_override=True,
+        )
+        if runtime != "codex":
+            return override
+        effective = merge_settings(default_runtime_settings(runtime), override)
+        return normalize_setting_constraints(
+            runtime,
+            effective,
+            explicit_keys=set(),
+            schema=schema,
         )
 
     async def patch_session_runtime_settings(
@@ -215,16 +363,7 @@ class RuntimeConfigService:
     ) -> dict[str, Any]:
         row = await self._runtime_settings.get_session_runtime_row(session_id, user_id=user_id)
         runtime = str(row["runtime"])
-        schema = await self.get_runtime_config_schema_for_user(
-            runtime,
-            user_id=user_id or str(row["connector_user_id"]),
-        )
-        # Allow values from ACP-discovered option lists (not only seed enums).
-        schema = await self._merge_schema_with_device_options(
-            schema,
-            connector_id=str(row.get("connector_id") or ""),
-            runtime=runtime,
-        )
+        schema = await self._get_session_runtime_config_schema(row, user_id=user_id)
         normalized_patch = validate_runtime_settings(
             runtime,
             patch,
@@ -260,7 +399,12 @@ class RuntimeConfigService:
             override_json=_json_dumps(next_override) if next_override else None,
             updated_at=utc_now(),
         )
-        return next_override
+        if runtime != "codex":
+            return next_override
+        # The durable override may omit inherited Codex values.  Preserve the
+        # response contract by returning the effective projection clients saw
+        # before this storage compatibility layer existed.
+        return next_effective
 
     async def get_effective_runtime_settings(
         self,
@@ -269,11 +413,38 @@ class RuntimeConfigService:
         user_id: str | None = None,
     ) -> dict[str, Any]:
         row = await self._runtime_settings.get_session_runtime_row(session_id, user_id=user_id)
-        runtime = str(row["runtime"])
-        schema = await self.get_runtime_config_schema_for_user(
-            runtime,
-            user_id=user_id or str(row["connector_user_id"]),
+        return await self._effective_runtime_settings_from_row(row, user_id=user_id)
+
+    async def get_effective_runtime_settings_for_message(
+        self,
+        session_id: str,
+        patch: dict[str, Any],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Validate ephemeral composer overrides against the device's live schema.
+
+        The result is intentionally not persisted as a session override.  This
+        keeps the composer contract identical to the settings API while
+        guaranteeing an invalid message cannot change session state or reach a
+        connector RPC.
+        """
+        row = await self._runtime_settings.get_session_runtime_row(session_id, user_id=user_id)
+        return await self._effective_runtime_settings_from_row(
+            row,
+            user_id=user_id,
+            patch=patch,
         )
+
+    async def _effective_runtime_settings_from_row(
+        self,
+        row: Any,
+        *,
+        user_id: str | None,
+        patch: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        runtime = str(row["runtime"])
+        schema = await self._get_session_runtime_config_schema(row, user_id=user_id)
         override = _json_loads(row["runtime_settings_override"])
         override_settings = filter_runtime_settings(
             normalize_runtime_settings(
@@ -290,6 +461,20 @@ class RuntimeConfigService:
             explicit_keys=set(),
             schema=schema,
         )
+        if patch:
+            normalized_patch = validate_runtime_settings(
+                runtime,
+                patch,
+                schema,
+                session_override=True,
+            )
+            effective = apply_settings_patch(
+                effective,
+                normalized_patch,
+                runtime=runtime,
+                explicit_keys=set(normalized_patch),
+                schema=schema,
+            )
         return effective
 
     async def get_initial_runtime_settings_for_connector_agent(
@@ -300,28 +485,92 @@ class RuntimeConfigService:
         user_id: str | None = None,
         patch: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        settings = await self.get_device_agent_settings(
+        bundle = await self.get_initial_runtime_settings_bundle(
+            connector_id,
+            runtime,
+            user_id=user_id,
+            patch=patch,
+        )
+        return bundle["effective"]
+
+    async def get_initial_runtime_settings_bundle(
+        self,
+        connector_id: str,
+        runtime: str,
+        *,
+        user_id: str | None = None,
+        cwd: str | None = None,
+        patch: dict[str, Any] | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Resolve effective, durable, and connector views from one snapshot."""
+        await self._runtime_settings.require_connector(connector_id, user_id=user_id)
+        schema = await self.get_device_runtime_config_schema(
             connector_id,
             runtime,
             user_id=user_id,
         )
-        effective = merge_settings(default_runtime_settings(runtime), settings)
-        if patch is None:
-            return effective
-        schema = await self.get_runtime_config_schema_for_user(runtime, user_id=user_id)
-        normalized_patch = validate_runtime_settings(
-            runtime,
-            patch,
+        raw_device_settings = _json_loads(
+            await self._runtime_settings.get_device_settings_json(connector_id, runtime)
+        )
+        stored_settings = filter_runtime_settings(
+            normalize_runtime_settings(
+                runtime,
+                raw_device_settings if isinstance(raw_device_settings, dict) else {},
+            ),
             schema,
             session_override=False,
         )
-        return apply_settings_patch(
-            effective,
-            normalized_patch,
-            runtime=runtime,
-            explicit_keys=set(normalized_patch),
+        effective = normalize_setting_constraints(
+            runtime,
+            merge_settings(default_runtime_settings(runtime), stored_settings),
+            explicit_keys=set(),
             schema=schema,
         )
+        if patch is not None:
+            normalized_patch = validate_runtime_settings(
+                runtime,
+                patch,
+                schema,
+                session_override=False,
+            )
+            effective = apply_settings_patch(
+                effective,
+                normalized_patch,
+                runtime=runtime,
+                explicit_keys=set(normalized_patch),
+                schema=schema,
+            )
+        inherited_keys = _inherited_keys_after_patch(runtime, raw_device_settings, patch)
+        durable = rollback_safe_inherited_runtime_settings(
+            runtime,
+            effective,
+            inherited_keys=inherited_keys,
+        )
+        connector = serializer_for_runtime(runtime).serialize(settings=effective, cwd=cwd)
+        return {"effective": effective, "durable": durable, "connector": connector}
+
+    async def get_durable_initial_runtime_settings_for_connector_agent(
+        self,
+        connector_id: str,
+        runtime: str,
+        *,
+        user_id: str | None = None,
+        patch: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return the session snapshot safe to write across a rollback.
+
+        The public/effective settings still project this server's default.
+        Only a model/effort inherited from the raw device row is collapsed to
+        ``null`` for durable session state; an explicit device or request
+        choice remains untouched.
+        """
+        bundle = await self.get_initial_runtime_settings_bundle(
+            connector_id,
+            runtime,
+            user_id=user_id,
+            patch=patch,
+        )
+        return bundle["durable"]
 
     async def serialize_initial_settings_for_connector_agent(
         self,
@@ -332,18 +581,36 @@ class RuntimeConfigService:
         cwd: str | None = None,
         patch: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        effective = await self.get_initial_runtime_settings_for_connector_agent(
+        bundle = await self.get_initial_runtime_settings_bundle(
             connector_id,
             runtime,
             user_id=user_id,
+            cwd=cwd,
             patch=patch,
         )
-        return serializer_for_runtime(runtime).serialize(settings=effective, cwd=cwd)
+        return bundle["connector"]
 
     async def _get_user_agent_defaults(self, user_id: str | None) -> dict[str, Any]:
         if user_id is None or self._user_defaults_provider is None:
             return {}
         return await self._user_defaults_provider.get_user_agent_defaults(user_id)
+
+    async def _get_session_runtime_config_schema(
+        self,
+        row: Any,
+        *,
+        user_id: str | None,
+    ) -> RuntimeConfigSchema:
+        runtime = str(row["runtime"])
+        schema = await self.get_runtime_config_schema_for_user(
+            runtime,
+            user_id=user_id or str(row["connector_user_id"]),
+        )
+        return await self._merge_schema_with_device_options(
+            schema,
+            connector_id=str(row.get("connector_id") or ""),
+            runtime=runtime,
+        )
 
     async def _merge_schema_with_device_options(
         self,
@@ -393,27 +660,30 @@ def seed_runtime_config_schemas_sync(async_url: str) -> None:
 def _seed_runtime_config_schemas_on_sync_conn(conn: Any) -> None:
     now = utc_now()
     for runtime, schema in DEFAULT_RUNTIME_CONFIG_SCHEMAS.items():
+        persisted = ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS.get(runtime, schema)
         key = runtime_schema_key(runtime)
+        persisted_json = _persistent_schema_json(persisted)
+        conn.execute(
+            _runtime_schema_insert_if_missing(
+                conn,
+                key=key,
+                value=persisted_json,
+                updated_at=now,
+            )
+        )
         existing = conn.execute(
             select(instance_settings_t.c.value).where(instance_settings_t.c.key == key)
         ).first()
-        if existing is None:
-            conn.execute(
-                insert(instance_settings_t).values(
-                    key=key,
-                    value=_json_dumps(schema.model_dump(exclude_none=True)),
-                    updated_at=now,
-                )
-            )
-            continue
-        if _stored_schema_version(existing.value) < schema.schemaVersion:
+        existing_value = existing.value if existing is not None else None
+        if _should_reseed_runtime_schema(runtime, existing_value, persisted):
+            values = {
+                "value": persisted_json,
+                "updated_at": now,
+            }
             conn.execute(
                 update(instance_settings_t)
                 .where(instance_settings_t.c.key == key)
-                .values(
-                    value=_json_dumps(schema.model_dump(exclude_none=True)),
-                    updated_at=now,
-                )
+                .values(**values)
             )
 
 
@@ -426,7 +696,17 @@ def _seed_runtime_config_schemas_async_in_thread(async_url: str) -> None:
             async with engine.begin() as conn:
                 now = utc_now()
                 for runtime, schema in DEFAULT_RUNTIME_CONFIG_SCHEMAS.items():
+                    persisted = ROLLBACK_SAFE_RUNTIME_CONFIG_SCHEMAS.get(runtime, schema)
                     key = runtime_schema_key(runtime)
+                    persisted_json = _persistent_schema_json(persisted)
+                    await conn.execute(
+                        _runtime_schema_insert_if_missing(
+                            conn,
+                            key=key,
+                            value=persisted_json,
+                            updated_at=now,
+                        )
+                    )
                     existing = (
                         await conn.execute(
                             select(instance_settings_t.c.value).where(
@@ -434,23 +714,16 @@ def _seed_runtime_config_schemas_async_in_thread(async_url: str) -> None:
                             )
                         )
                     ).first()
-                    if existing is None:
-                        await conn.execute(
-                            insert(instance_settings_t).values(
-                                key=key,
-                                value=_json_dumps(schema.model_dump(exclude_none=True)),
-                                updated_at=now,
-                            )
-                        )
-                        continue
-                    if _stored_schema_version(existing.value) < schema.schemaVersion:
+                    existing_value = existing.value if existing is not None else None
+                    if _should_reseed_runtime_schema(runtime, existing_value, persisted):
+                        values = {
+                            "value": persisted_json,
+                            "updated_at": now,
+                        }
                         await conn.execute(
                             update(instance_settings_t)
                             .where(instance_settings_t.c.key == key)
-                            .values(
-                                value=_json_dumps(schema.model_dump(exclude_none=True)),
-                                updated_at=now,
-                            )
+                            .values(**values)
                         )
         finally:
             await engine.dispose()

--- a/server/agent_server/services/session_run.py
+++ b/server/agent_server/services/session_run.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 import time
 from typing import Any
 
 from agent_server.infra.connector_rpc import ConnectorOfflineError, ConnectorRpcError, ConnectorRpcManager
 from agent_server.core.models import MessageCreateRequest, RpcResponsePayload, SessionCreateRequest
+from agent_server.core.runtime_config import PersistedRuntimeConfigError
 from agent_server.infra.perf import elapsed_ms, log_stage
 from agent_server.infra.runtimes.serializers import serializer_for_runtime
 from agent_server.infra.repositories.facade import Store
@@ -32,7 +34,7 @@ class SessionRunUpstreamError(SessionRunError):
 
 
 class SessionRunInvalidConfigError(SessionRunError):
-    status_code = 500
+    status_code = 422
 
 
 class SessionRunService:
@@ -56,12 +58,16 @@ class SessionRunService:
         connector_result = None
         if payload.externalSessionId is not None:
             try:
-                runtime_settings_override = await self._store.get_initial_runtime_settings_for_connector_agent(
+                settings_bundle = await self._store.get_initial_runtime_settings_bundle(
                     payload.connectorId,
                     payload.runtime,
                     user_id=user_id,
+                    cwd=payload.cwd,
                     patch=payload.runtimeSettings,
                 )
+                durable_runtime_settings = settings_bundle["durable"]
+            except (json.JSONDecodeError, PersistedRuntimeConfigError) as exc:
+                raise SessionRunError("invalid persisted runtime settings") from exc
             except ValueError as exc:
                 raise SessionRunInvalidConfigError(str(exc)) from exc
             session = await self._store.create_session(
@@ -71,7 +77,7 @@ class SessionRunService:
                 external_session_id=payload.externalSessionId,
                 title=payload.title,
                 cwd=payload.cwd,
-                runtime_settings_override=runtime_settings_override,
+                runtime_settings_override=durable_runtime_settings,
             )
             return {"session": session, "connectorResult": connector_result}
 
@@ -81,19 +87,18 @@ class SessionRunService:
         if auth_blocked is not None:
             raise SessionRunUpstreamError(auth_blocked)
         try:
-            runtime_settings_override = await self._store.get_initial_runtime_settings_for_connector_agent(
-                payload.connectorId,
-                payload.runtime,
-                user_id=user_id,
-                patch=payload.runtimeSettings,
-            )
-            connector_settings = await self._store.serialize_initial_settings_for_connector_agent(
+            settings_bundle = await self._store.get_initial_runtime_settings_bundle(
                 payload.connectorId,
                 payload.runtime,
                 user_id=user_id,
                 cwd=payload.cwd,
                 patch=payload.runtimeSettings,
             )
+            runtime_settings = settings_bundle["effective"]
+            durable_runtime_settings = settings_bundle["durable"]
+            connector_settings = settings_bundle["connector"]
+        except (json.JSONDecodeError, PersistedRuntimeConfigError) as exc:
+            raise SessionRunError("invalid persisted runtime settings") from exc
         except ValueError as exc:
             raise SessionRunInvalidConfigError(str(exc)) from exc
 
@@ -148,14 +153,14 @@ class SessionRunService:
             cwd=payload.cwd,
             status="idle",
             last_synced_at=utc_now(),
-            runtime_settings_override=runtime_settings_override,
+            runtime_settings_override=durable_runtime_settings,
             origin="platform",
         )
-        if session.runtimeSettings != runtime_settings_override:
+        if session.runtimeSettings != runtime_settings:
             session = session.model_copy(
                 update={
-                    "runtimeSettings": runtime_settings_override,
-                    "runtimeSettingsOverride": runtime_settings_override,
+                    "runtimeSettings": runtime_settings,
+                    "runtimeSettingsOverride": runtime_settings,
                 }
             )
         return {"session": session, "connectorResult": connector_result}
@@ -170,6 +175,8 @@ class SessionRunService:
         prep_started = time.perf_counter()
         try:
             session = await self._store.get_session(session_id, user_id=user_id)
+        except (json.JSONDecodeError, PersistedRuntimeConfigError) as exc:
+            raise SessionRunError("invalid persisted runtime settings") from exc
         except KeyError:
             raise SessionRunNotFoundError("session not found") from None
 
@@ -179,15 +186,29 @@ class SessionRunService:
             raise SessionRunConflictError("connector is offline")
         if session.status not in {"idle", "error"}:
             raise SessionRunConflictError(f"session is {session.status}")
+        message_settings: dict[str, Any] = {}
+        if session.runtime == "claude" and payload.mode is not None:
+            message_settings["permissionMode"] = payload.mode
+        if payload.model is not None:
+            message_settings["model"] = payload.model
+        if payload.effort is not None:
+            message_settings["effort"] = payload.effort
         try:
-            effective_settings = await self._store.get_effective_runtime_settings(
+            # Apply message overrides before status/active-run mutation.  The
+            # service reads the same device-live schema used by the settings
+            # endpoints, so an unsupported model/effort pair cannot bypass the
+            # contract through post-serialization parameter replacement.
+            effective_settings = await self._store.runtime_config.get_effective_runtime_settings_for_message(
                 session_id,
+                message_settings,
                 user_id=user_id,
             )
             runtime_params = serializer_for_runtime(session.runtime).serialize(
                 settings=effective_settings,
                 cwd=session.cwd,
             )
+        except (json.JSONDecodeError, PersistedRuntimeConfigError) as exc:
+            raise SessionRunError("invalid persisted runtime settings") from exc
         except ValueError as exc:
             raise SessionRunInvalidConfigError(str(exc)) from exc
 
@@ -202,12 +223,6 @@ class SessionRunService:
             params["cwd"] = session.cwd
         if session.externalSessionId:
             params["externalSessionId"] = session.externalSessionId
-        if session.runtime == "claude" and payload.mode is not None:
-            params["permissionMode"] = payload.mode
-        if payload.model is not None:
-            params["model"] = payload.model
-        if payload.effort is not None:
-            params["effort"] = payload.effort
         if payload.clientMessageId:
             params["clientMessageId"] = payload.clientMessageId
         if payload.attachments:

--- a/server/tests/test_acp_schema_merge.py
+++ b/server/tests/test_acp_schema_merge.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from agent_server.core.runtime_config import (
+    DEFAULT_RUNTIME_CONFIG_SCHEMAS,
     RuntimeConfigField,
     RuntimeConfigOption,
     RuntimeConfigSchema,
+    apply_settings_patch,
     merge_schema_with_agent_options,
+    schema_with_user_agent_defaults,
 )
 
 
@@ -53,3 +56,55 @@ def test_merge_schema_from_acp_config_options() -> None:
     keys = {field.key for field in merged.fields}
     assert "model" in keys
     assert "permissionMode" in keys
+
+
+def test_merge_codex_live_models_preserves_constraints_and_model_default_effort() -> None:
+    # A Codex device may only report the model names.  Static constraints must
+    # survive that overlay so a prior Sol/Ultra choice is normalized safely
+    # when the user switches to Luna.
+    base = schema_with_user_agent_defaults(DEFAULT_RUNTIME_CONFIG_SCHEMAS["codex"], None)
+    merged = merge_schema_with_agent_options(
+        base,
+        model_options=[
+            {
+                "model": "gpt-5.6-sol",
+                "displayName": "Sol from device",
+                "supportedReasoningEfforts": ["low", "medium", "ultra"],
+                "defaultReasoningEffort": "medium",
+                "isDefault": True,
+            },
+            {
+                "model": "gpt-5.6-luna",
+                "displayName": "Luna from device",
+                # Legacy device output omits effort metadata entirely.
+            },
+        ],
+    )
+
+    model_field = next(field for field in merged.fields if field.key == "model")
+    options = {str(option.value): option for option in model_field.options or []}
+    assert options["gpt-5.6-sol"].isDefault is True
+    assert options["gpt-5.6-sol"].label == "Sol from device"
+    assert [str(option.value) for option in options["gpt-5.6-sol"].efforts or []] == [
+        "low",
+        "medium",
+        "ultra",
+    ]
+    # Luna retains its static, more restrictive contract rather than treating
+    # missing live metadata as a no-effort declaration.
+    assert [str(option.value) for option in options["gpt-5.6-luna"].efforts or []] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+
+    switched = apply_settings_patch(
+        {"model": "gpt-5.6-sol", "effort": "ultra"},
+        {"model": "gpt-5.6-luna"},
+        runtime="codex",
+        explicit_keys={"model"},
+        schema=merged,
+    )
+    assert switched == {"model": "gpt-5.6-luna", "effort": "medium"}

--- a/server/tests/test_backend_mvp.py
+++ b/server/tests/test_backend_mvp.py
@@ -2422,7 +2422,7 @@ def test_legacy_v1_capabilities_blob_migrates_to_v3_view_on_read(tmp_path):
     assert state["disabled"] == []
 
 
-def test_send_message_forwards_codex_model_effort_but_ignores_legacy_mode(tmp_path):
+def test_send_message_validates_codex_model_effort_before_mutating_run_state(tmp_path):
     client = make_client(tmp_path)
     connector_id, _, session_id, headers = create_connector_and_session(client)
     fake_rpc = FakeLocalRpc()
@@ -2436,7 +2436,64 @@ def test_send_message_forwards_codex_model_effort_but_ignores_legacy_mode(tmp_pa
         json={
             "content": "hi",
             "mode": "bypassPermissions",
-            "model": "claude-opus-4-7",
+            "model": "gpt-5.6-luna",
+            "effort": "ultra",
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    assert fake_rpc.requests == []
+    assert asyncio.run(client.app.state.store.get_active_run(session_id)) is None
+    assert asyncio.run(client.app.state.store.get_session(session_id)).status == "idle"
+
+
+def test_send_message_reports_corrupt_persisted_runtime_settings_as_server_error(tmp_path):
+    client = make_client(tmp_path)
+    connector_id, _, session_id, headers = create_connector_and_session(client)
+    fake_rpc = FakeLocalRpc()
+    client.app.state.rpc = fake_rpc
+    asyncio.run(client.app.state.store.set_connector_status(connector_id, "online"))
+    client.post(f"/sessions/{session_id}/takeover", headers=headers).raise_for_status()
+
+    async def corrupt_override() -> None:
+        from sqlalchemy import update
+
+        from agent_server.infra.db import sessions as sessions_t
+
+        async with client.app.state.store.engine.begin() as conn:
+            await conn.execute(
+                update(sessions_t)
+                .where(sessions_t.c.id == session_id)
+                .values(runtime_settings_override="{not-json")
+            )
+
+    asyncio.run(corrupt_override())
+    response = client.post(
+        f"/sessions/{session_id}/messages",
+        headers=headers,
+        json={"content": "hi", "model": "gpt-5.6-sol", "effort": "medium"},
+    )
+
+    assert response.status_code == 500, response.text
+    assert response.json()["detail"] == "invalid persisted runtime settings"
+    assert fake_rpc.requests == []
+
+
+def test_send_message_forwards_valid_codex_model_effort_but_ignores_legacy_mode(tmp_path):
+    client = make_client(tmp_path)
+    connector_id, _, session_id, headers = create_connector_and_session(client)
+    fake_rpc = FakeLocalRpc()
+    client.app.state.rpc = fake_rpc
+    asyncio.run(client.app.state.store.set_connector_status(connector_id, "online"))
+    client.post(f"/sessions/{session_id}/takeover", headers=headers).raise_for_status()
+
+    response = client.post(
+        f"/sessions/{session_id}/messages",
+        headers=headers,
+        json={
+            "content": "hi",
+            "mode": "bypassPermissions",
+            "model": "gpt-5.6-luna",
             "effort": "max",
         },
     )
@@ -2454,7 +2511,7 @@ def test_send_message_forwards_codex_model_effort_but_ignores_legacy_mode(tmp_pa
         "excludeTmpdirEnvVar": True,
         "excludeSlashTmp": True,
     }
-    assert params["model"] == "claude-opus-4-7"
+    assert params["model"] == "gpt-5.6-luna"
     assert params["effort"] == "max"
 
 
@@ -2763,12 +2820,12 @@ def test_send_message_carries_runtime_for_claude_session(tmp_path):
     response = client.post(
         f"/sessions/{session_id}/messages",
         headers=headers,
-        json={"content": "hi", "mode": "auto"},
+        json={"content": "hi", "mode": "acceptEdits"},
     )
     assert response.status_code == 200, response.text
     params = fake_rpc.requests[-1][2]
     assert params["runtime"] == "claude"
-    assert params["permissionMode"] == "auto"
+    assert params["permissionMode"] == "acceptEdits"
     assert params["cwd"] == "/repo"
 
 

--- a/server/tests/test_catalog_seed_concurrency.py
+++ b/server/tests/test_catalog_seed_concurrency.py
@@ -1,0 +1,99 @@
+"""Exercise the actual startup seed path under competing processes/threads."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from sqlalchemy import delete, select
+
+from agent_server.infra.db import (
+    agent_efforts as agent_efforts_t,
+    agent_models as agent_models_t,
+    instance_settings as instance_settings_t,
+)
+from agent_server.infra.repositories.facade import Store
+
+
+def _concurrent_seed_stores(db_url: str) -> list[Store]:
+    """Start two catalog seeds at the same instant against an initialized DB.
+
+    Store construction invokes the synchronous catalog seed path, which is the
+    path that historically used a check-then-insert race.
+    """
+    # Table creation is a separate startup concern. Initialize it once, then
+    # race the actual catalog seed operation against stable schema metadata.
+    bootstrap = Store(db_url=db_url)
+
+    async def clear_seed_rows() -> None:
+        async with bootstrap.engine.begin() as conn:
+            await conn.execute(delete(agent_models_t).where(agent_models_t.c.runtime == "codex"))
+            await conn.execute(delete(agent_efforts_t).where(agent_efforts_t.c.runtime == "codex"))
+            await conn.execute(delete(instance_settings_t))
+
+    asyncio.run(clear_seed_rows())
+    asyncio.run(bootstrap.close())
+    barrier = threading.Barrier(2)
+
+    def construct() -> Store:
+        barrier.wait(timeout=10)
+        return Store(db_url=db_url)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(construct) for _ in range(2)]
+        return [future.result(timeout=30) for future in futures]
+
+
+async def _catalog_keys(store: Store) -> tuple[list[str], list[str]]:
+    async with store.engine.connect() as conn:
+        model_keys = list(
+            (
+                await conn.execute(
+                    select(agent_models_t.c.key)
+                    .where(agent_models_t.c.runtime == "codex")
+                    .order_by(agent_models_t.c.sort_order)
+                )
+            ).scalars()
+        )
+        effort_keys = list(
+            (
+                await conn.execute(
+                    select(agent_efforts_t.c.key)
+                    .where(agent_efforts_t.c.runtime == "codex")
+                    .order_by(agent_efforts_t.c.sort_order)
+                )
+            ).scalars()
+        )
+    return model_keys, effort_keys
+
+
+def _assert_seeded_once(stores: list[Store]) -> None:
+    try:
+        model_keys, effort_keys = asyncio.run(_catalog_keys(stores[0]))
+        assert model_keys == [
+            "gpt-5.5",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex",
+            "gpt-5.2",
+        ]
+        assert effort_keys == ["low", "medium", "high", "xhigh"]
+    finally:
+        for store in stores:
+            asyncio.run(store.close())
+
+
+def test_catalog_seed_is_atomic_under_concurrent_sqlite_startup(tmp_path: Path) -> None:
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'catalog-race.sqlite3'}"
+    _assert_seeded_once(_concurrent_seed_stores(db_url))
+
+
+def test_catalog_seed_is_atomic_under_concurrent_postgres_startup() -> None:
+    db_url = os.environ.get("AGENT_SERVER_DB_URL")
+    if not db_url or not db_url.startswith("postgresql"):
+        pytest.skip("AGENT_SERVER_DB_URL is not a live PostgreSQL database")
+    _assert_seeded_once(_concurrent_seed_stores(db_url))

--- a/server/tests/test_runtime_config.py
+++ b/server/tests/test_runtime_config.py
@@ -9,10 +9,18 @@ from fastapi.testclient import TestClient
 from sqlalchemy import delete, select, update
 
 from agent_server.app import create_app
-from agent_server.core.runtime_config import DEFAULT_RUNTIME_CONFIG_SCHEMAS
+from agent_server.core.runtime_config import (
+    DEFAULT_RUNTIME_CONFIG_SCHEMAS,
+    is_rollback_safe_codex_schema,
+    runtime_schema_key,
+    validate_runtime_schema,
+)
 from agent_server.infra.db import (
     agent_efforts as agent_efforts_t,
     agent_models as agent_models_t,
+    device_agent_settings as device_agent_settings_t,
+    instance_settings as instance_settings_t,
+    sessions as sessions_t,
     user_agent_defaults as user_agent_defaults_t,
 )
 
@@ -123,6 +131,248 @@ def test_runtime_config_schema_is_seeded_and_readable(tmp_path):
     fields = {field["key"]: field for field in body["schema"]["fields"]}
     assert "runMode" not in fields
     assert fields["permissionMode"]["allowSessionOverride"] is True
+
+
+def test_codex_v4_schema_is_virtual_over_rollback_safe_durable_schema(tmp_path):
+    client = make_client(tmp_path)
+    headers = auth_headers(client)
+    key = runtime_schema_key("codex")
+
+    async def raw_schema() -> str:
+        async with client.app.state.store.engine.connect() as conn:
+            return (
+                await conn.execute(
+                    select(instance_settings_t.c.value).where(instance_settings_t.c.key == key)
+                )
+            ).scalar_one()
+
+    durable_before = asyncio.run(raw_schema())
+    durable = json.loads(durable_before)
+    assert durable["schemaVersion"] == 3
+    assert "gpt-5.6" not in durable_before
+    assert '"max"' not in durable_before
+    assert '"ultra"' not in durable_before
+    assert "isDefault" not in durable_before
+
+    response = client.get("/agents/codex/config-schema", headers=headers)
+    assert response.status_code == 200, response.text
+    projected = response.json()["schema"]
+    assert projected["schemaVersion"] == 4
+    model_field = next(field for field in projected["fields"] if field["key"] == "model")
+    assert model_field["options"][0]["value"] == "gpt-5.6-sol"
+
+    # A read must not materialize v4/GPT-5.6 into the database.
+    assert asyncio.run(raw_schema()) == durable_before
+
+
+def test_runtime_schema_converges_exact_v4_and_heals_empty_but_preserves_custom(tmp_path):
+    client = make_client(tmp_path)
+    store = client.app.state.store
+    key = runtime_schema_key("codex")
+
+    async def read_raw() -> str:
+        async with store.engine.connect() as conn:
+            return (
+                await conn.execute(
+                    select(instance_settings_t.c.value).where(instance_settings_t.c.key == key)
+                )
+            ).scalar_one()
+
+    async def exercise() -> tuple[str, str, str, str]:
+        current = DEFAULT_RUNTIME_CONFIG_SCHEMAS["codex"].model_dump(exclude_none=True)
+        await store.set_runtime_config_schema("codex", current)
+        await store.seed_runtime_config_schemas()
+        converged = await read_raw()
+
+        # Empty same-version payloads are interrupted built-in seed shapes,
+        # and are safe to repair. A non-empty edited schema is operator data.
+        await store.instance_settings.set(
+            key,
+            json.dumps({"runtime": "codex", "schemaVersion": 4, "fields": []}),
+        )
+        await store.seed_runtime_config_schemas()
+        healed = await read_raw()
+
+        custom = deepcopy(current)
+        next(field for field in custom["fields"] if field["key"] == "model")["label"] = "Private model"
+        await store.set_runtime_config_schema("codex", custom)
+        before_custom_reseed = await read_raw()
+        await store.seed_runtime_config_schemas()
+        after_custom_reseed = await read_raw()
+
+        custom_constraints = deepcopy(current)
+        model_options = next(
+            field for field in custom_constraints["fields"] if field["key"] == "model"
+        )["options"]
+        model_options[0]["isDefault"] = False
+        model_options[1]["isDefault"] = True
+        model_options[0]["efforts"] = []
+        await store.set_runtime_config_schema("codex", custom_constraints)
+        before_constraint_reseed = await read_raw()
+        await store.seed_runtime_config_schemas()
+        after_constraint_reseed = await read_raw()
+        return (
+            converged,
+            healed,
+            before_custom_reseed,
+            after_custom_reseed,
+            before_constraint_reseed,
+            after_constraint_reseed,
+        )
+
+    converged, healed, custom_before, custom_after, constraints_before, constraints_after = asyncio.run(exercise())
+    assert is_rollback_safe_codex_schema(
+        validate_runtime_schema("codex", json.loads(converged))
+    )
+    assert is_rollback_safe_codex_schema(
+        validate_runtime_schema("codex", json.loads(healed))
+    )
+    assert "isDefault" not in converged
+    assert "isDefault" not in healed
+    assert custom_after == custom_before
+    assert constraints_after == constraints_before
+
+
+def test_user_defaults_empty_patch_preserves_raw_snapshot_and_explicit_empty_is_global(tmp_path):
+    client = make_client(tmp_path)
+    headers = auth_headers(client)
+    initial = client.patch(
+        "/agents/defaults",
+        headers=headers,
+        json={
+            "runtimes": {
+                "codex": {
+                    "models": [
+                        {
+                            "key": "private-model",
+                            "displayLabel": "Private model",
+                            "sortOrder": 1,
+                            "efforts": [
+                                {"key": "private-effort", "displayLabel": "Private effort", "sortOrder": 1}
+                            ],
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    assert initial.status_code == 200, initial.text
+
+    async def raw_models() -> str:
+        async with client.app.state.store.engine.connect() as conn:
+            return (
+                await conn.execute(
+                    select(user_agent_defaults_t.c.models_json).where(
+                        user_agent_defaults_t.c.user_id == ADMIN_USER,
+                        user_agent_defaults_t.c.runtime == "codex",
+                    )
+                )
+            ).scalar_one()
+
+    before_empty_patch = asyncio.run(raw_models())
+    no_op = client.patch("/agents/defaults", headers=headers, json={"runtimes": {"codex": {}}})
+    assert no_op.status_code == 200, no_op.text
+    assert asyncio.run(raw_models()) == before_empty_patch
+
+    clear = client.patch(
+        "/agents/defaults",
+        headers=headers,
+        json={"runtimes": {"codex": {"models": []}}},
+    )
+    assert clear.status_code == 200, clear.text
+    assert asyncio.run(raw_models()) == "[]"
+    # `[]` is explicit global catalog selection, not a malformed snapshot.
+    assert clear.json()["runtimes"]["codex"]["models"][0]["key"] == "gpt-5.6-sol"
+
+
+def test_malformed_persisted_models_are_observable_and_never_rewritten(tmp_path):
+    client = make_client(tmp_path)
+    headers = auth_headers(client)
+    seeded = client.patch(
+        "/agents/defaults",
+        headers=headers,
+        json={
+            "runtimes": {
+                "codex": {
+                    "models": [
+                        {
+                            "key": "private-model",
+                            "displayLabel": "Private model",
+                            "sortOrder": 1,
+                            "efforts": [],
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    assert seeded.status_code == 200, seeded.text
+    connector_id, _, session_id, _ = create_connector_and_session(client)
+
+    corrupt = "{not-json"
+
+    async def corrupt_and_read() -> str:
+        async with client.app.state.store.engine.begin() as conn:
+            await conn.execute(
+                update(user_agent_defaults_t)
+                .where(
+                    user_agent_defaults_t.c.user_id == ADMIN_USER,
+                    user_agent_defaults_t.c.runtime == "codex",
+                )
+                .values(models_json=corrupt)
+            )
+        async with client.app.state.store.engine.connect() as conn:
+            return (
+                await conn.execute(
+                    select(user_agent_defaults_t.c.models_json).where(
+                        user_agent_defaults_t.c.user_id == ADMIN_USER,
+                        user_agent_defaults_t.c.runtime == "codex",
+                    )
+                )
+            ).scalar_one()
+
+    assert asyncio.run(corrupt_and_read()) == corrupt
+    assert client.get("/agents/defaults", headers=headers).status_code == 500
+    assert client.get("/agents/codex/models", headers=headers).status_code == 500
+    assert client.get("/agents/codex/efforts", headers=headers).status_code == 500
+    assert client.patch(
+        "/agents/defaults",
+        headers=headers,
+        json={"runtimes": {"codex": {"models": []}}},
+    ).status_code == 500
+    assert client.patch(
+        f"/connectors/{connector_id}/agents/codex/settings",
+        headers=headers,
+        json={"settings": {"effort": "medium"}},
+    ).status_code == 500
+    assert client.patch(
+        f"/sessions/{session_id}/runtime-settings",
+        headers=headers,
+        json={"settings": {"effort": "medium"}},
+    ).status_code == 500
+
+    client.app.state.rpc = FakeRpc()
+    client.post(f"/sessions/{session_id}/takeover", headers=headers).raise_for_status()
+    send = client.post(
+        f"/sessions/{session_id}/messages",
+        headers=headers,
+        json={"content": "hi"},
+    )
+    assert send.status_code == 500, send.text
+    assert send.json()["detail"] == "invalid persisted runtime settings"
+
+    async def read_raw() -> str:
+        async with client.app.state.store.engine.connect() as conn:
+            return (
+                await conn.execute(
+                    select(user_agent_defaults_t.c.models_json).where(
+                        user_agent_defaults_t.c.user_id == ADMIN_USER,
+                        user_agent_defaults_t.c.runtime == "codex",
+                    )
+                )
+            ).scalar_one()
+
+    assert asyncio.run(read_raw()) == corrupt
 
 
 def test_user_agent_defaults_customize_schema_and_new_connectors(tmp_path):
@@ -320,6 +570,19 @@ def test_codex_catalog_upgrade_inherits_only_legacy_builtin_snapshots(tmp_path):
     )
     assert cleared.status_code == 200, cleared.text
 
+    async def cleared_schema_version() -> int:
+        async with client.app.state.store.engine.connect() as conn:
+            return (
+                await conn.execute(
+                    select(device_agent_settings_t.c.schema_version).where(
+                        device_agent_settings_t.c.connector_id == null_connector,
+                        device_agent_settings_t.c.runtime == "codex",
+                    )
+                )
+            ).scalar_one()
+
+    assert asyncio.run(cleared_schema_version()) == 3
+
     async def downgrade_and_reseed() -> None:
         legacy_schema = deepcopy(DEFAULT_RUNTIME_CONFIG_SCHEMAS["codex"]).model_dump(
             exclude_none=True
@@ -338,6 +601,8 @@ def test_codex_catalog_upgrade_inherits_only_legacy_builtin_snapshots(tmp_path):
                     for option in field["options"]
                     if option["value"] not in {"max", "ultra"}
                 ]
+            for option in field.get("options") or []:
+                option["isDefault"] = False
         await client.app.state.store.set_runtime_config_schema("codex", legacy_schema)
 
         async with client.app.state.store.engine.begin() as conn:
@@ -451,8 +716,10 @@ def test_codex_catalog_upgrade_inherits_only_legacy_builtin_snapshots(tmp_path):
 
     models = asyncio.run(client.app.state.store.list_agent_models("codex"))
     efforts = asyncio.run(client.app.state.store.list_agent_efforts("codex"))
-    assert [model.key for model in models if model.isDefault] == ["gpt-5.6-sol"]
-    assert [effort.key for effort in efforts if effort.isDefault] == ["medium"]
+    # Durable rows intentionally remain readable by a base-main rollback;
+    # the v4/GPT-5.6 catalog above is an in-memory projection.
+    assert [model.key for model in models if model.isDefault] == ["gpt-5.5"]
+    assert [effort.key for effort in efforts if effort.isDefault] == ["xhigh"]
 
 
 def test_first_discovery_respects_user_agent_default_enabled(tmp_path):
@@ -727,6 +994,132 @@ def test_codex_sol_medium_defaults_are_sent_to_connector(tmp_path):
     assert method == "turn.start"
     assert params["model"] == "gpt-5.6-sol"
     assert params["effort"] == "medium"
+
+
+def test_automatic_codex_defaults_are_durable_but_projected_as_sol_medium(tmp_path):
+    client = make_client(tmp_path)
+    headers = auth_headers(client)
+
+    # Materialize the user-default row through an automatic catalog update.
+    # It must not write the current server's model/effort as a durable choice.
+    defaults = client.patch(
+        "/agents/defaults",
+        headers=headers,
+        json={"runtimes": {"codex": {"models": []}}},
+    )
+    assert defaults.status_code == 200, defaults.text
+    assert defaults.json()["runtimes"]["codex"]["settings"] == {
+        "permissionMode": "ask",
+        "model": "gpt-5.6-sol",
+        "effort": "medium",
+    }
+
+    connector = client.post("/connectors", headers=headers, json={"name": "dev"})
+    assert connector.status_code == 200, connector.text
+    connector_id = connector.json()["connector"]["id"]
+
+    # A non-model settings patch still inherits the model and effort.
+    permission = client.patch(
+        f"/connectors/{connector_id}/agents/codex/settings",
+        headers=headers,
+        json={"settings": {"permissionMode": "auto"}},
+    )
+    assert permission.status_code == 200, permission.text
+    assert permission.json()["settings"] == {
+        "permissionMode": "auto",
+        "model": "gpt-5.6-sol",
+        "effort": "medium",
+    }
+
+    automatic = client.post(
+        "/sessions",
+        headers=headers,
+        json={
+            "connectorId": connector_id,
+            "runtime": "codex",
+            "externalSessionId": "thr_automatic_defaults",
+            "title": "Automatic defaults",
+            "cwd": "/repo",
+        },
+    )
+    assert automatic.status_code == 200, automatic.text
+    assert automatic.json()["session"]["runtimeSettings"]["model"] == "gpt-5.6-sol"
+    assert automatic.json()["session"]["runtimeSettings"]["effort"] == "medium"
+
+    async def raw_automatic() -> tuple[str, dict[str, Any], str]:
+        async with client.app.state.store.engine.connect() as conn:
+            user_defaults = (
+                await conn.execute(
+                    select(user_agent_defaults_t.c.settings_json).where(
+                        user_agent_defaults_t.c.user_id == ADMIN_USER,
+                        user_agent_defaults_t.c.runtime == "codex",
+                    )
+                )
+            ).scalar_one()
+            device = (
+                await conn.execute(
+                    select(
+                        device_agent_settings_t.c.settings_json,
+                        device_agent_settings_t.c.schema_version,
+                    ).where(
+                        device_agent_settings_t.c.connector_id == connector_id,
+                        device_agent_settings_t.c.runtime == "codex",
+                    )
+                )
+            ).mappings().one()
+            session = (
+                await conn.execute(
+                    select(sessions_t.c.runtime_settings_override).where(
+                        sessions_t.c.id == automatic.json()["session"]["id"]
+                    )
+                )
+            ).scalar_one()
+        return user_defaults, dict(device), session
+
+    durable_defaults, durable_device, durable_session = asyncio.run(raw_automatic())
+    assert json.loads(durable_defaults)["model"] is None
+    assert json.loads(durable_defaults)["effort"] is None
+    assert json.loads(durable_device["settings_json"]) == {
+        "permissionMode": "auto",
+        "model": None,
+        "effort": None,
+    }
+    assert durable_device["schema_version"] == 3
+    assert json.loads(durable_session) == {
+        "permissionMode": "auto",
+        "model": None,
+        "effort": None,
+    }
+    assert all("gpt-5.6" not in raw for raw in (durable_defaults, durable_device["settings_json"], durable_session))
+
+    # An explicit selection equal to the current default is still a user
+    # choice and therefore must not be collapsed to nullable inheritance.
+    explicit = client.patch(
+        f"/connectors/{connector_id}/agents/codex/settings",
+        headers=headers,
+        json={"settings": {"model": "gpt-5.6-sol", "effort": "medium"}},
+    )
+    assert explicit.status_code == 200, explicit.text
+
+    async def raw_explicit() -> tuple[dict[str, Any], str]:
+        async with client.app.state.store.engine.connect() as conn:
+            device = (
+                await conn.execute(
+                    select(
+                        device_agent_settings_t.c.settings_json,
+                        device_agent_settings_t.c.schema_version,
+                    ).where(
+                        device_agent_settings_t.c.connector_id == connector_id,
+                        device_agent_settings_t.c.runtime == "codex",
+                    )
+                )
+            ).mappings().one()
+        return dict(device), device["settings_json"]
+
+    explicit_device, explicit_device_json = asyncio.run(raw_explicit())
+    assert json.loads(explicit_device_json)["model"] == "gpt-5.6-sol"
+    assert json.loads(explicit_device_json)["effort"] == "medium"
+    assert explicit_device["schema_version"] == 4
 
 
 def test_custom_model_efforts_drive_runtime_settings_validation(tmp_path):


### PR DESCRIPTION
## Summary

- publish the validated, paginated Codex model catalog from the connector, including per-model effort constraints
- make server runtime schemas and catalogs rollback-safe, concurrency-safe, and observable when persisted configuration is malformed
- consume device-effective runtime schemas on iOS and normalize effort when users switch models
- restore iOS build compatibility and split the oversized session timeline view without changing its behavior

## Why

The earlier GPT-5.6 catalog change established static defaults, but the end-to-end contract still allowed connector discovery, durable server state, runtime validation, and the iOS selector to disagree. That could expose invalid model/effort combinations, overwrite inherited settings during rollback or startup races, and leave the client using a stale global schema instead of the effective device schema.

This follow-up makes the connector the validated source of live model capabilities, keeps durable state rollback-safe, validates runtime settings before mutating session run state, and carries the effective per-model contract through to iOS.

## User impact

- Codex model and effort choices reflect the connector-reported catalog.
- Switching models automatically preserves or selects a valid effort and hides effort where the model exposes none.
- Invalid combinations fail before a session run is mutated.
- Built-in catalog/schema upgrades converge safely without rewriting custom or malformed persisted values.

## Validation

- Connector suite: **170 passed**
- Server suite: **221 passed, 1 skipped, 2 failed**
  - both failures reproduce on the clean baseline:
    - `test_interrupt_does_not_mark_session_idle_before_turn_end`
    - `test_dashboard_events_route_precedes_session_events`
- Focused server contract tests: **24 passed, 1 skipped**
- iOS generic simulator `build-for-testing`: **passed** (test bundle compiled and linked)
- iOS Release generic device build: **passed**
- `git diff --check`: **passed**
- targeted Ruff E9/F821 and Python compile checks: **passed**

## Environment limitations

- XCTest execution was not possible because the installed simulator runtime is 26.5 while the deployment target is 26.6; compilation and linking succeeded.
- Live PostgreSQL concurrency coverage was not run because the local Homebrew PostgreSQL 18 shared directory is missing; the SQLite concurrency test passed.

## Commits

- `aeacc98` fix(ios): restore build compatibility for runtime contract tests
- `28c157a` fix(connector): publish validated Codex model capabilities
- `9e6beca` fix(server): enforce rollback-safe Codex runtime contracts
- `800742d` feat(ios): consume per-model runtime effort contracts
