### PR TITLE
fix(server): prevent path traversal (LFI) in static file fallback route

### DIFF
--- a/server/agent_server/app.py
+++ b/server/agent_server/app.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import AsyncIterator
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -42,6 +42,20 @@ from agent_server.infra.timeline_broker import TimelineBroker
 
 
 CONNECTOR_PRESENCE_SWEEP_SECONDS = 5
+
+
+def _safe_static_path(candidate: Path, root: Path) -> bool:
+    """Reject any candidate that escapes the static root (LFI / path traversal).
+
+    Path traversal payloads like ``../``, ``%2e%2e%2f`` or absolute paths are
+    normalized by ``resolve()`` and then checked against the static root, so
+    only files physically under ``root`` are served.
+    """
+    try:
+        resolved = candidate.resolve(strict=False)
+        return resolved.is_relative_to(root.resolve())
+    except OSError:
+        return False
 
 
 async def _connector_presence_watchdog(app: FastAPI) -> None:
@@ -136,7 +150,11 @@ def create_app(db_path: str | Path | None = None) -> FastAPI:
             relative = path.strip("/")
             default_locale = os.environ.get("AGENT_SERVER_STATIC_DEFAULT_LOCALE", "en")
             if relative:
+                if ".." in relative.split("/"):
+                    raise HTTPException(status_code=404, detail="not found")
                 candidate = static_path / relative
+                if not _safe_static_path(candidate, static_path):
+                    raise HTTPException(status_code=404, detail="not found")
                 if candidate.is_dir() and (candidate / "index.html").is_file():
                     return FileResponse(candidate / "index.html")
                 if candidate.is_file():


### PR DESCRIPTION
## Summary
Fixes #27 (Security: unauthenticated path traversal / LFI in static file fallback route)

The unauthenticated catch-all route `/{path:path}` in `agent_server/app.py` serves files from `AGENT_SERVER_STATIC_DIR` without validating the resolved path stays inside the static root. An attacker can read arbitrary files inside the container via encoded traversal payloads (e.g. `/..%2f..%2f..%2fetc%2fpasswd`), including the SQLite DB, env secrets and source code.

## Fix
Two layers of defense in `_static_index`:
1. Reject any request whose path segments contain `..` (404).
2. After joining with the static root, resolve the candidate and require it to be relative to the resolved static root (`Path.is_relative_to`).

## Verification
- Normal static assets (`/`, subdirs, `_next`, `assets`) still serve correctly.
- Traversal payloads (`../`, `%2e%2e/`, `%2f` encoded) now return 404 `{"detail":"not found"}`.
- Backend API routes unaffected.
