### PR TITLE
Fix Android token expiry redirect

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/android/app/src/main/java/com/agentsanywhere/app/api/ApiClient.kt
+++ b/android/app/src/main/java/com/agentsanywhere/app/api/ApiClient.kt
@@ -5,7 +5,9 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 
-class ApiClient {
+class ApiClient(
+    private val onUnauthorized: (accessToken: String) -> Unit = {},
+) {
     fun getJson(
         serverUrl: String,
         path: String,
@@ -82,6 +84,7 @@ class ApiClient {
     fun streamSse(
         serverUrl: String,
         path: String,
+        authorizationToken: String? = null,
         onOpen: () -> Unit = {},
         onEvent: (JSONObject) -> Unit,
     ) {
@@ -98,6 +101,7 @@ class ApiClient {
             val responseCode = connection.responseCode
             if (responseCode !in 200..299) {
                 val responseText = readResponseText(connection, responseCode)
+                notifyUnauthorized(responseCode, authorizationToken)
                 throw ApiException(
                     message = parseErrorMessage(responseText) ?: defaultErrorMessage(responseCode),
                     statusCode = responseCode,
@@ -169,6 +173,7 @@ class ApiClient {
                 val responseCode = connection.responseCode
                 val responseText = readResponseText(connection, responseCode)
                 if (responseCode !in 200..299) {
+                    notifyUnauthorized(responseCode, authorizationToken)
                     throw ApiException(
                         message = parseErrorMessage(responseText) ?: defaultErrorMessage(responseCode),
                         statusCode = responseCode,
@@ -221,6 +226,7 @@ class ApiClient {
                 val responseCode = connection.responseCode
                 val responseText = readResponseText(connection, responseCode)
                 if (responseCode !in 200..299) {
+                    notifyUnauthorized(responseCode, authorizationToken)
                     throw ApiException(
                         message = parseErrorMessage(responseText) ?: defaultErrorMessage(responseCode),
                         statusCode = responseCode,
@@ -236,6 +242,11 @@ class ApiClient {
         } catch (exc: IOException) {
             throw ApiException("Could not reach the server. Check the URL and network.", cause = exc)
         }
+    }
+
+    internal fun notifyUnauthorized(statusCode: Int, authorizationToken: String?) {
+        if (statusCode != 401 || authorizationToken.isNullOrBlank()) return
+        runCatching { onUnauthorized(authorizationToken) }
     }
 
     private fun readResponseText(connection: HttpURLConnection, responseCode: Int): String {

--- a/android/app/src/main/java/com/agentsanywhere/app/api/SessionsApi.kt
+++ b/android/app/src/main/java/com/agentsanywhere/app/api/SessionsApi.kt
@@ -171,6 +171,7 @@ class SessionsApi(
         client.streamSse(
             serverUrl = serverUrl,
             path = "/sessions/${sessionId.urlEncode()}/events?token=${authorizationToken.urlEncode()}",
+            authorizationToken = authorizationToken,
             onOpen = onOpen,
         ) { event ->
             onEvent(event.toRemoteSessionEvent())

--- a/android/app/src/main/java/com/agentsanywhere/app/api/TerminalApi.kt
+++ b/android/app/src/main/java/com/agentsanywhere/app/api/TerminalApi.kt
@@ -74,6 +74,10 @@ class TerminalApi(
             "?fromSeq=$fromSeq&token=${authorizationToken.urlEncode()}"
     }
 
+    internal fun notifyUnauthorized(authorizationToken: String) {
+        client.notifyUnauthorized(statusCode = 401, authorizationToken = authorizationToken)
+    }
+
     private fun JSONObject.toRemoteTerminal(): RemoteTerminal {
         return RemoteTerminal(
             terminalId = getString("terminalId"),

--- a/android/app/src/main/java/com/agentsanywhere/app/app/AgentsAnywhereApp.kt
+++ b/android/app/src/main/java/com/agentsanywhere/app/app/AgentsAnywhereApp.kt
@@ -1,5 +1,8 @@
 package com.agentsanywhere.app.app
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.Uri
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
@@ -11,6 +14,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +25,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.agentsanywhere.app.api.ApiClient
 import com.agentsanywhere.app.api.AuthApi
 import com.agentsanywhere.app.api.DevicesApi
 import com.agentsanywhere.app.api.FilesApi
@@ -76,6 +84,8 @@ import com.agentsanywhere.app.ui.screens.home.HomeTab
 import com.agentsanywhere.app.ui.screens.home.HomeScreen
 import com.agentsanywhere.app.ui.screens.home.NewSessionScreen
 import com.agentsanywhere.app.ui.screens.terminal.TerminalScreen
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -106,42 +116,48 @@ fun AgentsAnywhereApp(
     var selectedDeviceId by rememberSaveable { mutableStateOf<String?>(null) }
     var deviceDetailReturnDestinationName by rememberSaveable { mutableStateOf(AppDestination.Devices.name) }
     var selectedHomeTabName by rememberSaveable { mutableStateOf(HomeTab.Active.name) }
-    val authController = remember(context, sessionStore) {
+    val unauthorizedTokens = remember { Channel<String>(capacity = Channel.UNLIMITED) }
+    val apiClient = remember(unauthorizedTokens) {
+        ApiClient(onUnauthorized = { accessToken ->
+            unauthorizedTokens.trySend(accessToken)
+        })
+    }
+    val authController = remember(context, sessionStore, apiClient) {
         AuthController(
-            api = AuthApi(),
+            api = AuthApi(apiClient),
             sessionStore = sessionStore,
         )
     }
-    val sessionsController = remember(context, sessionStore) {
+    val sessionsController = remember(context, sessionStore, apiClient) {
         SessionsController(
-            sessionsApi = SessionsApi(),
-            devicesApi = DevicesApi(),
-            filesApi = FilesApi(),
+            sessionsApi = SessionsApi(apiClient),
+            devicesApi = DevicesApi(apiClient),
+            filesApi = FilesApi(apiClient),
             sessionStore = sessionStore,
         )
     }
-    val devicesController = remember(context, sessionStore) {
+    val devicesController = remember(context, sessionStore, apiClient) {
         DevicesController(
-            devicesApi = DevicesApi(),
+            devicesApi = DevicesApi(apiClient),
             sessionStore = sessionStore,
-            sessionsApi = SessionsApi(),
+            sessionsApi = SessionsApi(apiClient),
         )
     }
-    val sessionDetailController = remember(context, sessionStore) {
+    val sessionDetailController = remember(context, sessionStore, apiClient) {
         SessionDetailController(
-            sessionsApi = SessionsApi(),
+            sessionsApi = SessionsApi(apiClient),
             sessionStore = sessionStore,
         )
     }
-    val filesController = remember(context, sessionStore) {
+    val filesController = remember(context, sessionStore, apiClient) {
         FilesController(
-            filesApi = FilesApi(),
+            filesApi = FilesApi(apiClient),
             sessionStore = sessionStore,
         )
     }
-    val terminalController = remember(context, sessionStore) {
+    val terminalController = remember(context, sessionStore, apiClient) {
         TerminalController(
-            terminalApi = TerminalApi(),
+            terminalApi = TerminalApi(apiClient),
             sessionStore = sessionStore,
         )
     }
@@ -161,6 +177,62 @@ fun AgentsAnywhereApp(
     }
     var isRefreshingSessions by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    fun clearSessionAndReturnToLogin(expectedToken: String? = null) {
+        val didClearSession = if (expectedToken == null) {
+            authController.signOut()
+            true
+        } else {
+            sessionStore.clearAuthSessionIfTokenMatches(expectedToken)
+        }
+        if (!didClearSession) return
+
+        remoteTerminalPool.disposeLocal()
+        sessionsState = SessionsState()
+        isRefreshingSessions = false
+        selectedSessionId = null
+        selectedDeviceId = null
+        pendingMobileLoginQr = null
+        oauthFlow = null
+        oauthErrorMessage = null
+        destinationName = AppDestination.LoginMethods.name
+    }
+
+    LaunchedEffect(unauthorizedTokens) {
+        for (accessToken in unauthorizedTokens) {
+            clearSessionAndReturnToLogin(expectedToken = accessToken)
+        }
+    }
+
+    DisposableEffect(lifecycleOwner, hasAuthSession, authController, context) {
+        if (!hasAuthSession) {
+            return@DisposableEffect onDispose {}
+        }
+
+        var validationJob: Job? = null
+        fun validateSessionIfOnline() {
+            if (!context.hasUsableNetwork() || validationJob?.isActive == true) return
+            validationJob = scope.launch {
+                authController.me()
+            }
+        }
+
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_START) {
+                validateSessionIfOnline()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            validateSessionIfOnline()
+        }
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            validationJob?.cancel()
+        }
+    }
+
     suspend fun refreshSessions(showInitialLoading: Boolean, showRefreshIndicator: Boolean) {
         if (showRefreshIndicator) {
             isRefreshingSessions = true
@@ -316,12 +388,7 @@ fun AgentsAnywhereApp(
         onClearAvatar = { authController.clearAvatar() },
         onChangePassword = { password -> authController.changePassword(password) },
         onSignOut = {
-            remoteTerminalPool.disposeLocal()
-            authController.signOut()
-            sessionsState = SessionsState()
-            selectedSessionId = null
-            selectedDeviceId = null
-            destinationName = AppDestination.LoginMethods.name
+            clearSessionAndReturnToLogin()
         },
         onRenameDevice = { connectorId, name ->
             if (!hasAuthSession) {
@@ -714,6 +781,13 @@ private fun AgentsAnywhereNavHost(
             onClaimDevicePairCode = onClaimDevicePairCode,
         )
     }
+}
+
+private fun Context.hasUsableNetwork(): Boolean {
+    val connectivityManager = getSystemService(ConnectivityManager::class.java)
+    val activeNetwork = connectivityManager.activeNetwork ?: return false
+    val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 }
 
 @Preview(showBackground = true, widthDp = 390, heightDp = 844)

--- a/android/app/src/main/java/com/agentsanywhere/app/feature/auth/AuthSessionStore.kt
+++ b/android/app/src/main/java/com/agentsanywhere/app/feature/auth/AuthSessionStore.kt
@@ -58,7 +58,19 @@ class AuthSessionStore(context: Context) {
             .apply()
     }
 
+    @Synchronized
     fun clearAuthSession() {
+        clearAuthSessionKeepingServerUrl()
+    }
+
+    @Synchronized
+    fun clearAuthSessionIfTokenMatches(accessToken: String): Boolean {
+        if (accessToken.isBlank() || readAccessToken() != accessToken) return false
+        clearAuthSessionKeepingServerUrl()
+        return true
+    }
+
+    private fun clearAuthSessionKeepingServerUrl() {
         val serverUrl = readServerUrl()
         preferences.edit()
             .clear()

--- a/android/app/src/main/java/com/agentsanywhere/app/feature/terminal/RemoteTerminalController.kt
+++ b/android/app/src/main/java/com/agentsanywhere/app/feature/terminal/RemoteTerminalController.kt
@@ -71,6 +71,7 @@ class RemoteTerminalController(
     private var connectorId: String? = null
     private var terminalId: String? = null
     private var streamUrl: String? = null
+    private var streamAuthorizationToken: String? = null
     private var reconnectScheduled = false
     private var reconnectAttempts = 0
     private var lastSeenSeq = 0L
@@ -121,6 +122,7 @@ class RemoteTerminalController(
                 connectorId = connection.connectorId
                 terminalId = connection.terminal.terminalId
                 streamUrl = connection.streamUrl
+                streamAuthorizationToken = connection.authorizationToken
                 lastSeenSeq = 0L
                 reconnectAttempts = 0
                 remoteTerminalGone = false
@@ -163,6 +165,7 @@ class RemoteTerminalController(
                 connectorId = connection.connectorId
                 terminalId = connection.terminal.terminalId
                 streamUrl = connection.streamUrl
+                streamAuthorizationToken = connection.authorizationToken
                 lastSeenSeq = 0L
                 reconnectAttempts = 0
                 remoteTerminalGone = false
@@ -314,6 +317,7 @@ class RemoteTerminalController(
         connectorId = null
         terminalId = null
         streamUrl = null
+        streamAuthorizationToken = null
         reconnectScheduled = false
         reconnectAttempts = 0
         remoteTerminalGone = false
@@ -365,6 +369,10 @@ class RemoteTerminalController(
                     diag("ws failure ${t::class.java.simpleName}: ${t.message} manual=$manuallyClosed terminal=$terminalId")
                     if (socket !== webSocket) return
                     socket = null
+                    if (response?.code == 401) {
+                        streamAuthorizationToken?.let(terminalController::notifyUnauthorized)
+                        return
+                    }
                     if (!manuallyClosed) {
                         scheduleReconnect()
                     }
@@ -511,6 +519,7 @@ class RemoteTerminalController(
         connectorId = null
         terminalId = null
         streamUrl = null
+        streamAuthorizationToken = null
         reconnectScheduled = false
         remoteTerminalGone = false
         cancelPendingRemoteResize()

--- a/android/app/src/main/java/com/agentsanywhere/app/feature/terminal/TerminalController.kt
+++ b/android/app/src/main/java/com/agentsanywhere/app/feature/terminal/TerminalController.kt
@@ -42,6 +42,7 @@ class TerminalController(
                     connectorId = session.connectorId,
                     terminal = terminal,
                     streamUrl = terminalApi.streamUrl(auth.serverUrl, auth.accessToken, session.connectorId, terminal.terminalId),
+                    authorizationToken = auth.accessToken,
                 )
             }.recoverCatching { error ->
                 if (error is ApiException) throw error
@@ -78,6 +79,7 @@ class TerminalController(
                     connectorId = connectorId,
                     terminal = terminal,
                     streamUrl = terminalApi.streamUrl(auth.serverUrl, auth.accessToken, connectorId, terminal.terminalId),
+                    authorizationToken = auth.accessToken,
                 )
             }.recoverCatching { error ->
                 if (error is ApiException) throw error
@@ -132,6 +134,10 @@ class TerminalController(
         return ApiAuth(serverUrl = serverUrl, accessToken = accessToken)
     }
 
+    internal fun notifyUnauthorized(authorizationToken: String) {
+        terminalApi.notifyUnauthorized(authorizationToken)
+    }
+
     private data class ApiAuth(
         val serverUrl: String,
         val accessToken: String,
@@ -161,4 +167,5 @@ data class WorkspaceTerminalConnection(
     val connectorId: String,
     val terminal: RemoteTerminal,
     val streamUrl: String,
+    val authorizationToken: String,
 )

--- a/android/app/src/test/java/com/agentsanywhere/app/api/ApiClientTest.kt
+++ b/android/app/src/test/java/com/agentsanywhere/app/api/ApiClientTest.kt
@@ -1,0 +1,77 @@
+package com.agentsanywhere.app.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+import kotlin.concurrent.thread
+
+class ApiClientTest {
+    @Test
+    fun `authenticated 401 notifies unauthorized listener`() {
+        val notifiedTokens = mutableListOf<String>()
+        val client = ApiClient(onUnauthorized = notifiedTokens::add)
+
+        client.notifyUnauthorized(statusCode = 401, authorizationToken = "expired-token")
+
+        assertEquals(listOf("expired-token"), notifiedTokens)
+    }
+
+    @Test
+    fun `query-authenticated stream 401 notifies unauthorized listener`() {
+        val notifiedTokens = mutableListOf<String>()
+        val client = ApiClient(onUnauthorized = notifiedTokens::add)
+        val error = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1")).use { serverSocket ->
+            val serverThread = thread {
+                serverSocket.accept().use { socket ->
+                    val reader = socket.getInputStream().bufferedReader()
+                    while (!reader.readLine().isNullOrEmpty()) Unit
+                    val body = "{\"detail\":\"invalid user access token\"}"
+                    socket.getOutputStream().bufferedWriter().use { writer ->
+                        writer.write("HTTP/1.1 401 Unauthorized\r\n")
+                        writer.write("Content-Type: application/json\r\n")
+                        writer.write("Content-Length: ${body.toByteArray(Charsets.UTF_8).size}\r\n")
+                        writer.write("Connection: close\r\n\r\n")
+                        writer.write(body)
+                    }
+                }
+            }
+            val result = runCatching {
+                client.streamSse(
+                    serverUrl = "http://${serverSocket.inetAddress.hostAddress}:${serverSocket.localPort}",
+                    path = "/events?token=expired-stream-token",
+                    authorizationToken = "expired-stream-token",
+                    onEvent = {},
+                )
+            }
+            serverThread.join(1_000)
+            result.exceptionOrNull()
+        }
+
+        assertEquals(listOf("expired-stream-token"), notifiedTokens)
+        assertTrue(error is ApiException && error.statusCode == 401)
+    }
+
+    @Test
+    fun `unauthenticated 401 does not notify unauthorized listener`() {
+        val notifiedTokens = mutableListOf<String>()
+        val client = ApiClient(onUnauthorized = notifiedTokens::add)
+
+        client.notifyUnauthorized(statusCode = 401, authorizationToken = null)
+        client.notifyUnauthorized(statusCode = 401, authorizationToken = "")
+
+        assertEquals(emptyList<String>(), notifiedTokens)
+    }
+
+    @Test
+    fun `authenticated non-401 does not notify unauthorized listener`() {
+        val notifiedTokens = mutableListOf<String>()
+        val client = ApiClient(onUnauthorized = notifiedTokens::add)
+
+        client.notifyUnauthorized(statusCode = 403, authorizationToken = "valid-token")
+        client.notifyUnauthorized(statusCode = 500, authorizationToken = "valid-token")
+
+        assertEquals(emptyList<String>(), notifiedTokens)
+    }
+}


### PR DESCRIPTION
## Summary

- add centralized unauthorized handling to the shared Android API client
- validate the saved token with `/auth/me` on cold start and whenever the app enters the foreground while online
- clear expired authentication state and terminal connections while preserving the configured server URL
- redirect to the login methods screen without displaying raw server token errors
- handle authenticated 401 responses from JSON, multipart, SSE, and terminal WebSocket handshake paths
- ignore delayed 401 responses from an old token after a new login and make concurrent 401 handling idempotent

## Root cause

The Android client treated any non-empty saved token as a valid session. Authenticated API 401 responses were surfaced as ordinary page errors, so an expired seven-day token produced `invalid user access token` on the home screen instead of clearing the session and returning the user to login.

## User impact

Expired sessions now return users to the login flow automatically. Offline, timeout, and 5xx failures continue to preserve the local login state. Login endpoint 401 responses still remain credential errors on the login screen.

## Validation

- `./gradlew testDebugUnitTest` — 4 tests passed
- `./gradlew assembleDebug` — passed
- `git diff --check` — passed
- rebased onto the latest `origin/main` without conflicts

Android Lint was also run. The repository still has two pre-existing errors unrelated to this change: the API 26 `windowLightNavigationBar` style compatibility issue and the camera permission hardware-feature declaration.
