### PR TITLE
fix(desktop): refine Windows title bar and sidebar layout

### DIFF
--- a/desktop-workbench/electron/development-login.test.ts
+++ b/desktop-workbench/electron/development-login.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import vm from "node:vm";
+import ts from "typescript";
+
+function loginFixture(platform: string) {
+  const windows: LoginWindow[] = [];
+  class LoginWindow extends EventEmitter {
+    closed = false;
+    styles: string[] = [];
+    webContents = Object.assign(new EventEmitter(), {
+      setWindowOpenHandler: () => {},
+      insertCSS: async (css: string) => { this.styles.push(css); return "style"; },
+    });
+    constructor(readonly options: Electron.BrowserWindowConstructorOptions) {
+      super();
+      windows.push(this);
+    }
+    isDestroyed() { return this.closed; }
+    destroy() { this.closed = true; }
+    close() { this.closed = true; }
+    show() {}
+    setTitle() {}
+    async loadURL() { this.webContents.emit("dom-ready"); }
+  }
+  const source = fs.readFileSync(path.resolve(__dirname, "../../electron/development-login.ts"), "utf8");
+  const javascript = ts.transpileModule(source, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS },
+  }).outputText;
+  const exports = {} as {
+    openDevelopmentLoginWindow: (options: { parent: null; authorizeUrl: string; onCallback: (url: string) => void }) => Promise<string>;
+  };
+  vm.runInNewContext(javascript, {
+    exports,
+    process: { platform },
+    URL,
+    console,
+    require: (name: string) => {
+      if (name === "electron") return { BrowserWindow: LoginWindow };
+      if (name === "./desktop-oauth") return { DESKTOP_OAUTH_PROTOCOL: "agents-anywhere-desktop" };
+      throw new Error(`Unexpected import: ${name}`);
+    },
+  });
+  return { windows, open: exports.openDevelopmentLoginWindow };
+}
+
+test("Windows login hides native branding while retaining controls, dragging and sandboxing", async () => {
+  const fixture = loginFixture("win32");
+  const callbacks: string[] = [];
+  await fixture.open({ parent: null, authorizeUrl: "https://example.com/authorize", onCallback: url => callbacks.push(url) });
+  const window = fixture.windows[0];
+  assert.equal(window.options.titleBarStyle, "hidden");
+  assert.equal((window.options.titleBarOverlay as Electron.TitleBarOverlay).height, 32);
+  assert.equal(window.options.webPreferences?.sandbox, true);
+  assert.equal(window.options.webPreferences?.nodeIntegration, false);
+  assert.match(window.styles[0], /-webkit-app-region: drag/);
+  assert.match(window.styles[0], /padding-top: 32px/);
+  assert.match(window.styles[0], /titlebar-area-width/);
+  window.webContents.emit("dom-ready");
+  assert.equal(window.styles.length, 2);
+  const callbackUrl = "agents-anywhere-desktop://callback?code=test";
+  let prevented = false;
+  window.webContents.emit("will-redirect", { preventDefault: () => { prevented = true; } }, callbackUrl);
+  assert.equal(prevented, true);
+  assert.deepEqual(callbacks, [callbackUrl]);
+  assert.equal(window.closed, true);
+});
+
+test("other platforms retain their existing login title bar", async () => {
+  for (const platform of ["darwin", "linux"]) {
+    const fixture = loginFixture(platform);
+    await fixture.open({ parent: null, authorizeUrl: "https://example.com/authorize", onCallback() {} });
+    const window = fixture.windows[0];
+    assert.equal(window.options.titleBarStyle, "default");
+    assert.equal(window.options.titleBarOverlay, undefined);
+    assert.equal(window.styles.length, 0);
+  }
+});

--- a/desktop-workbench/electron/development-login.ts
+++ b/desktop-workbench/electron/development-login.ts
@@ -29,6 +29,10 @@ export async function openDevelopmentLoginWindow(
     show: false,
     parent: options.parent && !options.parent.isDestroyed() ? options.parent : undefined,
     title: APP_NAME,
+    titleBarStyle: process.platform === "win32" ? "hidden" : "default",
+    titleBarOverlay: process.platform === "win32"
+      ? { color: "#09090b", symbolColor: "#fafafa", height: 32 }
+      : undefined,
     autoHideMenuBar: true,
     backgroundColor: "#09090b",
     webPreferences: {
@@ -40,6 +44,33 @@ export async function openDevelopmentLoginWindow(
     },
   });
   developmentLoginWindow = window;
+
+  if (process.platform === "win32") {
+    window.webContents.on("dom-ready", () => {
+      void window.webContents.insertCSS(`
+        body {
+          padding-top: 32px !important;
+          box-sizing: border-box;
+        }
+        .min-h-screen {
+          min-height: calc(100vh - 32px) !important;
+        }
+        html::before {
+          content: "";
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: env(titlebar-area-width, calc(100% - 138px));
+          height: 32px;
+          background: #09090b;
+          z-index: 2147483647;
+          -webkit-app-region: drag;
+        }
+      `).catch((error: unknown) => {
+        if (!window.isDestroyed()) console.warn("Failed to style the development login title bar.", error);
+      });
+    });
+  }
 
   let settled = false;
   const acceptCallback = (url: string): boolean => {

--- a/desktop-workbench/electron/main.ts
+++ b/desktop-workbench/electron/main.ts
@@ -29,6 +29,7 @@ import { DesktopDeviceService } from "./desktop-device-service";
 import { DesktopSettingsStore } from "./desktop-settings";
 import { ConnectorLogStore } from "./log-store";
 import { readShellEnvironment } from "./shell-environment";
+import { validateTitleBarColors } from "./title-bar";
 import config from "../config.json";
 import { proxyDesktopApi } from "./api-proxy";
 import {
@@ -288,7 +289,10 @@ function createMainWindow(showOnReady = true): BrowserWindow {
     show: false,
     title: APP_NAME,
     icon: appWindowIcon(),
-    titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
+    titleBarStyle: process.platform === "darwin" || process.platform === "win32" ? "hidden" : "default",
+    titleBarOverlay: process.platform === "win32"
+      ? { color: "#171717", symbolColor: "#fafafa", height: 32 }
+      : undefined,
     trafficLightPosition: process.platform === "darwin" ? { x: 17, y: 16 } : undefined,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
@@ -453,6 +457,11 @@ function appendMainLog(entry: string | Partial<ConnectorLogEntry>): void {
 }
 
 function registerIpcHandlers(): void {
+  ipcMain.handle("workbench:window:setTitleBarColors", (event, input: unknown) => {
+    assertTrustedRenderer(event);
+    if (process.platform !== "win32" || event.sender !== mainWindow?.webContents) return;
+    mainWindow.setTitleBarOverlay(validateTitleBarColors(input));
+  });
   ipcMain.handle("workbench:openExternal", async (event, url: string) => {
     assertTrustedRenderer(event);
     if (!/^https?:\/\//i.test(url)) throw new Error("Only http(s) URLs can be opened externally.");

--- a/desktop-workbench/electron/preload.ts
+++ b/desktop-workbench/electron/preload.ts
@@ -27,6 +27,10 @@ function subscribe<T>(channel: string, callback: (value: T) => void): () => void
 
 contextBridge.exposeInMainWorld("desktopWorkbench", {
   platform: process.platform,
+  window: {
+    setTitleBarColors: (colors: { color: string; symbolColor: string }): Promise<void> =>
+      ipcRenderer.invoke("workbench:window:setTitleBarColors", colors),
+  },
   versions: {
     chrome: process.versions.chrome,
     electron: process.versions.electron,

--- a/desktop-workbench/electron/title-bar.test.ts
+++ b/desktop-workbench/electron/title-bar.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateTitleBarColors } from "./title-bar";
+
+test("title bar accepts sidebar colors for both themes", () => {
+  for (const colors of [
+    { color: "#171717", symbolColor: "#fafafa" },
+    { color: "#fafafa", symbolColor: "#0a0a0a" },
+  ]) {
+    assert.deepEqual(validateTitleBarColors(colors), colors);
+  }
+});
+
+test("title bar rejects malformed IPC colors and ignores unrelated options", () => {
+  for (const input of [null, undefined, "dark", {}, { color: "red", symbolColor: "#ffffff" },
+    { color: "#171717", symbolColor: 123 }, { color: "#171717", symbolColor: "#fff" }]) {
+    assert.throws(() => validateTitleBarColors(input), /Invalid title bar colors/);
+  }
+  assert.deepEqual(validateTitleBarColors({ color: "#171717", symbolColor: "#FAFAFA", height: 500 }),
+    { color: "#171717", symbolColor: "#FAFAFA" });
+});

--- a/desktop-workbench/electron/title-bar.ts
+++ b/desktop-workbench/electron/title-bar.ts
@@ -1,0 +1,9 @@
+export function validateTitleBarColors(input: unknown): { color: string; symbolColor: string } {
+  if (!input || typeof input !== "object") throw new Error("Invalid title bar colors.");
+  const { color, symbolColor } = input as Record<string, unknown>;
+  if (typeof color !== "string" || !/^#[\da-f]{6}$/i.test(color)
+    || typeof symbolColor !== "string" || !/^#[\da-f]{6}$/i.test(symbolColor)) {
+    throw new Error("Invalid title bar colors.");
+  }
+  return { color, symbolColor };
+}

--- a/desktop-workbench/renderer/src/app/globals.css
+++ b/desktop-workbench/renderer/src/app/globals.css
@@ -189,6 +189,41 @@ body {
   -webkit-app-region: drag;
 }
 
+html[data-windows-title-bar] {
+  --aa-title-bar-height: 32px;
+}
+
+html[data-windows-title-bar] body {
+  padding-top: var(--aa-title-bar-height);
+}
+
+.aa-windows-title-bar {
+  position: fixed;
+  inset: 0 0 auto;
+  height: var(--aa-title-bar-height);
+  padding-right: calc(100vw - env(titlebar-area-width, calc(100vw - 138px)) + 12px);
+}
+
+html[data-windows-title-bar] .h-svh {
+  height: calc(100svh - var(--aa-title-bar-height));
+}
+
+html[data-windows-title-bar] .aa-auth-shell {
+  height: calc(100dvh - var(--aa-title-bar-height));
+}
+
+html[data-windows-title-bar] .min-h-screen {
+  min-height: calc(100vh - var(--aa-title-bar-height));
+}
+
+html[data-windows-title-bar] .aa-auth-shell > header {
+  top: var(--aa-title-bar-height);
+}
+
+html[data-windows-title-bar] [data-slot="sidebar-container"] {
+  top: var(--aa-title-bar-height);
+}
+
 /* Hallmark · studied: yes · source: user login reference · existing Geist tokens
  * Pre-emit critique: P5 H5 E4 S5 R5 V4. The native window owns the chrome.
  */

--- a/desktop-workbench/renderer/src/app/globals.css
+++ b/desktop-workbench/renderer/src/app/globals.css
@@ -224,6 +224,10 @@ html[data-windows-title-bar] [data-slot="sidebar-container"] {
   top: var(--aa-title-bar-height);
 }
 
+html[data-windows-title-bar] [data-slot="session-tool-sidebar"] {
+  top: var(--aa-title-bar-height);
+}
+
 /* Hallmark · studied: yes · source: user login reference · existing Geist tokens
  * Pre-emit critique: P5 H5 E4 S5 R5 V4. The native window owns the chrome.
  */

--- a/desktop-workbench/renderer/src/components/demo.tsx
+++ b/desktop-workbench/renderer/src/components/demo.tsx
@@ -181,6 +181,13 @@ function DesktopResizableShell() {
   const panelMotionClassName = sidebarResizeActive
     ? "[&>[data-panel]]:transition-none"
     : "[&>[data-panel]]:transition-[flex-grow] [&>[data-panel]]:duration-[220ms] [&>[data-panel]]:ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:[&>[data-panel]]:transition-none"
+  const shellHeader = (
+    <DesktopShellHeader
+      key="desktop-shell-header"
+      sidebarOpen={open}
+      sidebarResizing={sidebarResizeActive}
+    />
+  )
 
   return (
     <DashboardSidebarControlsContext.Provider value={sidebarControls}>
@@ -191,10 +198,7 @@ function DesktopResizableShell() {
           "--desktop-sidebar-width": `${Math.max(sidebarWidth, DESKTOP_SIDEBAR_MIN_WIDTH)}px`,
         } as React.CSSProperties}
       >
-        <DesktopShellHeader
-          sidebarOpen={open}
-          sidebarResizing={sidebarResizeActive}
-        />
+        {titleBarControls ? null : shellHeader}
         <ResizablePanelGroup
           id="agents-anywhere-dashboard-sidebar"
           defaultLayout={defaultLayout}
@@ -259,6 +263,7 @@ function DesktopResizableShell() {
             </SidebarInset>
           </ResizablePanel>
         </ResizablePanelGroup>
+        {titleBarControls ? shellHeader : null}
       </div>
       <SessionToolSidebarsHost />
     </DashboardSidebarControlsContext.Provider>

--- a/desktop-workbench/renderer/src/components/demo.tsx
+++ b/desktop-workbench/renderer/src/components/demo.tsx
@@ -7,6 +7,7 @@ import { SidebarProvider, SidebarInset, useSidebar } from "@/components/ui/sideb
 import { DashboardSidebarControlsContext } from "@/components/dashboard-sidebar-controls"
 import { AppSidebar } from "@/components/app-sidebar"
 import { DesktopShellHeader } from "@/components/desktop/desktop-shell-header"
+import { WindowsTitleBarControlsContext } from "@/components/desktop/windows-title-bar"
 import { DesktopSessionNotifications } from "@/components/desktop/desktop-session-notifications"
 import { TaskComposer } from "@/components/task-composer"
 import { SessionView } from "@/components/session-view"
@@ -40,6 +41,7 @@ import {
 } from "@/components/ui/resizable"
 import { useTranslations } from "next-intl"
 import { DesktopConnectorProvider } from "@/features/desktop/desktop-connector-context"
+import { cn } from "@/lib/utils"
 
 const SIDEBAR_LAYOUT_STORAGE_KEY = "agents-anywhere-dashboard-sidebar-layout"
 const DEFAULT_DESKTOP_LAYOUT = {
@@ -83,6 +85,7 @@ function DashboardShell() {
 
 function DesktopResizableShell() {
   const { open, setOpen } = useSidebar()
+  const titleBarControls = React.useContext(WindowsTitleBarControlsContext)
   const desktopShellRef = React.useRef<HTMLDivElement | null>(null)
   const sidebarPanelRef = React.useRef<PanelImperativeHandle | null>(null)
   const sidebarMotionActiveRef = React.useRef(false)
@@ -183,7 +186,7 @@ function DesktopResizableShell() {
     <DashboardSidebarControlsContext.Provider value={sidebarControls}>
       <div
         ref={desktopShellRef}
-        className="flex h-svh min-h-0 w-full flex-col overflow-hidden overscroll-none bg-background"
+        className={cn("flex h-svh min-h-0 w-full flex-col overflow-hidden overscroll-none bg-background", titleBarControls && "relative")}
         style={{
           "--desktop-sidebar-width": `${Math.max(sidebarWidth, DESKTOP_SIDEBAR_MIN_WIDTH)}px`,
         } as React.CSSProperties}
@@ -251,7 +254,7 @@ function DesktopResizableShell() {
             onLostPointerCapture={() => setSidebarResizeActive(false)}
           />
           <ResizablePanel id="dashboard-main" minSize={0} className="min-w-0">
-            <SidebarInset className="h-full min-h-0 overflow-hidden overscroll-none bg-background">
+            <SidebarInset className={cn("h-full min-h-0 overflow-hidden overscroll-none bg-background", titleBarControls && "pt-11")}>
               <WorkspaceMain />
             </SidebarInset>
           </ResizablePanel>

--- a/desktop-workbench/renderer/src/components/desktop/desktop-shell-header.tsx
+++ b/desktop-workbench/renderer/src/components/desktop/desktop-shell-header.tsx
@@ -101,9 +101,10 @@ export function DesktopShellHeader({
 
   return (
     <header
+      data-slot="desktop-shell-header"
       className={cn(
         "aa-window-drag flex h-11 shrink-0 items-center bg-background text-foreground",
-        titleBarControls ? "absolute top-0 right-0 z-10" : "relative",
+        titleBarControls ? "absolute top-0 right-0" : "relative",
       )}
       style={titleBarControls ? { left: sidebarOpen ? "var(--desktop-sidebar-width)" : 0 } : undefined}
     >

--- a/desktop-workbench/renderer/src/components/desktop/desktop-shell-header.tsx
+++ b/desktop-workbench/renderer/src/components/desktop/desktop-shell-header.tsx
@@ -1,16 +1,19 @@
 "use client"
 
 import * as React from "react"
+import { createPortal } from "react-dom"
 import { ArrowLeft, ArrowRight, Eraser, Info } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { toast } from "sonner"
 
 import { DashboardSidebarToggle } from "@/components/dashboard-sidebar-toggle"
+import { WindowsTitleBarControlsContext } from "@/components/desktop/windows-title-bar"
 import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
 import { useWorkspace } from "@/components/workspace-context"
 import { getDesktopWorkbenchBridge } from "@/features/desktop/bridge"
 import { useDesktopConnector } from "@/features/desktop/desktop-connector-context"
+import { cn } from "@/lib/utils"
 
 const HEADER_SIDEBAR_MIN_WIDTH = 224
 
@@ -24,6 +27,7 @@ export function DesktopShellHeader({
   const t = useTranslations("desktopConnector")
   const tCommon = useTranslations("common")
   const { canGoBack, canGoForward, goBack, goForward } = useWorkspace()
+  const titleBarControls = React.useContext(WindowsTitleBarControlsContext)
   const { supported, busy, state, binding, reconnect } = useDesktopConnector()
   const [canClearCache, setCanClearCache] = React.useState(false)
   const [clearingCache, setClearingCache] = React.useState(false)
@@ -39,7 +43,7 @@ export function DesktopShellHeader({
   const sidebarWidthMotionClassName = sidebarResizing
     ? "transition-none"
     : "transition-[width] duration-[220ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
-  const shellControlClassName = sidebarOpen
+  const shellControlClassName = sidebarOpen || titleBarControls
     ? "rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
     : "rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
 
@@ -60,8 +64,49 @@ export function DesktopShellHeader({
     }
   }, [t])
 
+  const navigationControls = (
+    <div className="aa-window-no-drag flex min-w-0 items-center gap-2">
+      <DashboardSidebarToggle
+        showOnDesktop
+        className={shellControlClassName}
+      />
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={tCommon("back")}
+          title={tCommon("back")}
+          onClick={goBack}
+          disabled={!canGoBack}
+          className={shellControlClassName}
+        >
+          <ArrowLeft className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={tCommon("forward")}
+          title={tCommon("forward")}
+          onClick={goForward}
+          disabled={!canGoForward}
+          className={shellControlClassName}
+        >
+          <ArrowRight className="size-4" />
+        </Button>
+      </div>
+    </div>
+  )
+
   return (
-    <header className="aa-window-drag relative flex h-11 shrink-0 items-center bg-background text-foreground">
+    <header
+      className={cn(
+        "aa-window-drag flex h-11 shrink-0 items-center bg-background text-foreground",
+        titleBarControls ? "absolute top-0 right-0 z-10" : "relative",
+      )}
+      style={titleBarControls ? { left: sidebarOpen ? "var(--desktop-sidebar-width)" : 0 } : undefined}
+    >
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-border/80"
@@ -69,48 +114,21 @@ export function DesktopShellHeader({
       <div
         aria-hidden="true"
         className={`pointer-events-none absolute inset-y-0 left-0 bg-sidebar ${sidebarWidthMotionClassName}`}
-        style={{ width: sidebarOpen ? "var(--desktop-sidebar-width)" : 0 }}
+        style={{ width: sidebarOpen && !titleBarControls ? "var(--desktop-sidebar-width)" : 0 }}
       />
       <div
         className={sidebarOpen
           ? `relative flex h-full shrink-0 items-center text-sidebar-foreground ${sidebarWidthMotionClassName}`
           : `relative flex h-full shrink-0 items-center text-foreground ${sidebarWidthMotionClassName}`
         }
-        style={{ width: headerSidebarWidth }}
+        style={{ width: titleBarControls ? 0 : headerSidebarWidth }}
       >
-        <div className="w-[6.5rem] shrink-0" aria-hidden="true" />
-        <div className="aa-window-no-drag flex min-w-0 items-center gap-2">
-          <DashboardSidebarToggle
-            showOnDesktop
-            className={shellControlClassName}
-          />
-          <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={tCommon("back")}
-              title={tCommon("back")}
-              onClick={goBack}
-              disabled={!canGoBack}
-              className={shellControlClassName}
-            >
-              <ArrowLeft className="size-4" />
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={tCommon("forward")}
-              title={tCommon("forward")}
-              onClick={goForward}
-              disabled={!canGoForward}
-              className={shellControlClassName}
-            >
-              <ArrowRight className="size-4" />
-            </Button>
-          </div>
-        </div>
+        {titleBarControls ? createPortal(navigationControls, titleBarControls) : (
+          <>
+            <div className="w-[6.5rem] shrink-0" aria-hidden="true" />
+            {navigationControls}
+          </>
+        )}
       </div>
       <div
         data-slot="desktop-shell-header-session"
@@ -158,7 +176,7 @@ export function DesktopShellHeader({
           className="aa-window-no-drag flex shrink-0 items-center"
         />
       </div>
-      {!sidebarOpen ? (
+      {!sidebarOpen && !titleBarControls ? (
         <div
           aria-hidden="true"
           className="pointer-events-none absolute top-1/2 h-5 w-px -translate-y-1/2 bg-border/60"

--- a/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
+++ b/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
@@ -4,7 +4,19 @@ import * as React from "react"
 import { useTheme } from "next-themes"
 
 import { getDesktopWorkbenchBridge } from "@/features/desktop/bridge"
-import appIcon from "../../../../build/icon-mac-source.png"
+
+export const WindowsTitleBarControlsContext = React.createContext<HTMLDivElement | null>(null)
+
+export function WindowsTitleBarProvider({ children }: { children: React.ReactNode }) {
+  const [controlsTarget, setControlsTarget] = React.useState<HTMLDivElement | null>(null)
+
+  return (
+    <WindowsTitleBarControlsContext.Provider value={controlsTarget}>
+      <WindowsTitleBar onControlsMount={setControlsTarget} />
+      {children}
+    </WindowsTitleBarControlsContext.Provider>
+  )
+}
 
 export function readTitleBarColors(element: HTMLElement) {
   const style = getComputedStyle(element)
@@ -27,7 +39,11 @@ export function readTitleBarColors(element: HTMLElement) {
   return { color: toHex(style.backgroundColor), symbolColor: toHex(style.color) }
 }
 
-export function WindowsTitleBar() {
+export function WindowsTitleBar({
+  onControlsMount,
+}: {
+  onControlsMount?: React.RefCallback<HTMLDivElement>
+} = {}) {
   const { resolvedTheme } = useTheme()
   const [enabled, setEnabled] = React.useState(false)
   const titleBarRef = React.useRef<HTMLDivElement>(null)
@@ -55,14 +71,12 @@ export function WindowsTitleBar() {
   if (!enabled) return null
 
   return (
-    <div ref={titleBarRef} className="aa-windows-title-bar aa-window-drag flex items-center gap-2 bg-sidebar px-3 text-xs text-sidebar-foreground">
-      <img
-        src={appIcon.src}
-        alt=""
-        className="size-4 shrink-0 object-contain"
-        draggable={false}
+    <div ref={titleBarRef} className="aa-windows-title-bar aa-window-drag flex items-center bg-sidebar px-3 text-sidebar-foreground">
+      <div
+        ref={onControlsMount}
+        data-slot="windows-title-bar-controls"
+        className="flex min-w-0 items-center"
       />
-      <span className="truncate">Agents Anywhere</span>
     </div>
   )
 }

--- a/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
+++ b/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import * as React from "react"
+import { useTheme } from "next-themes"
+
+import { getDesktopWorkbenchBridge } from "@/features/desktop/bridge"
+
+export function readTitleBarColors(element: HTMLElement) {
+  const style = getComputedStyle(element)
+  const canvas = document.createElement("canvas")
+  canvas.width = 1
+  canvas.height = 1
+  const context = canvas.getContext("2d")
+  if (!context) return null
+
+  const toHex = (color: string) => {
+    context.clearRect(0, 0, 1, 1)
+    context.fillStyle = color
+    context.fillRect(0, 0, 1, 1)
+    return "#" + Array.from(context.getImageData(0, 0, 1, 1).data)
+      .slice(0, 3)
+      .map((channel) => channel.toString(16).padStart(2, "0"))
+      .join("")
+  }
+
+  return { color: toHex(style.backgroundColor), symbolColor: toHex(style.color) }
+}
+
+export function WindowsTitleBar() {
+  const { resolvedTheme } = useTheme()
+  const [enabled, setEnabled] = React.useState(false)
+  const titleBarRef = React.useRef<HTMLDivElement>(null)
+
+  React.useLayoutEffect(() => {
+    const bridge = getDesktopWorkbenchBridge()
+    if (bridge?.platform !== "win32" || !bridge.window) return
+    document.documentElement.dataset.windowsTitleBar = "true"
+    setEnabled(true)
+    return () => { delete document.documentElement.dataset.windowsTitleBar }
+  }, [])
+
+  React.useEffect(() => {
+    if (!enabled) return
+    const frame = requestAnimationFrame(() => {
+      if (!titleBarRef.current) return
+      const colors = readTitleBarColors(titleBarRef.current)
+      if (colors) {
+        void getDesktopWorkbenchBridge()?.window?.setTitleBarColors(colors).catch(console.error)
+      }
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [enabled, resolvedTheme])
+
+  if (!enabled) return null
+
+  return (
+    <div ref={titleBarRef} className="aa-windows-title-bar aa-window-drag flex items-center gap-2 bg-sidebar px-3 text-xs text-sidebar-foreground">
+      <img
+        src={resolvedTheme === "dark" ? "/icon-dark-32x32.png" : "/icon-light-32x32.png"}
+        alt=""
+        className="size-4"
+        draggable={false}
+      />
+      <span className="truncate">Agents Anywhere</span>
+    </div>
+  )
+}

--- a/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
+++ b/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { useTheme } from "next-themes"
 
 import { getDesktopWorkbenchBridge } from "@/features/desktop/bridge"
+import appIcon from "../../../../build/icon-mac-source.png"
 
 export function readTitleBarColors(element: HTMLElement) {
   const style = getComputedStyle(element)
@@ -56,9 +57,9 @@ export function WindowsTitleBar() {
   return (
     <div ref={titleBarRef} className="aa-windows-title-bar aa-window-drag flex items-center gap-2 bg-sidebar px-3 text-xs text-sidebar-foreground">
       <img
-        src={resolvedTheme === "dark" ? "/icon-dark-32x32.png" : "/icon-light-32x32.png"}
+        src={appIcon.src}
         alt=""
-        className="size-4"
+        className="size-4 shrink-0 object-contain"
         draggable={false}
       />
       <span className="truncate">Agents Anywhere</span>

--- a/desktop-workbench/renderer/src/components/session-tool-sidebar.tsx
+++ b/desktop-workbench/renderer/src/components/session-tool-sidebar.tsx
@@ -584,11 +584,12 @@ export function SessionToolSidebar({
 
   return createPortal(
     <aside
+      data-slot="session-tool-sidebar"
       aria-label={t("sidebarLabel")}
       aria-hidden={!presented || !controller.open}
       inert={!presented || !controller.open ? true : undefined}
       className={cn(
-        "fixed top-[var(--aa-title-bar-height,0px)] bottom-0 z-40 flex min-w-0 flex-col overflow-hidden border-l border-border bg-background text-foreground",
+        "fixed inset-y-0 z-40 flex min-w-0 flex-col overflow-hidden border-l border-border bg-background text-foreground",
         presented && controller.open ? "visible" : "invisible",
         presented && controller.open ? "pointer-events-auto" : "pointer-events-none",
         motionEnabled && !fillsMain

--- a/desktop-workbench/renderer/src/components/session-tool-sidebar.tsx
+++ b/desktop-workbench/renderer/src/components/session-tool-sidebar.tsx
@@ -588,7 +588,7 @@ export function SessionToolSidebar({
       aria-hidden={!presented || !controller.open}
       inert={!presented || !controller.open ? true : undefined}
       className={cn(
-        "fixed inset-y-0 z-40 flex min-w-0 flex-col overflow-hidden border-l border-border bg-background text-foreground",
+        "fixed top-[var(--aa-title-bar-height,0px)] bottom-0 z-40 flex min-w-0 flex-col overflow-hidden border-l border-border bg-background text-foreground",
         presented && controller.open ? "visible" : "invisible",
         presented && controller.open ? "pointer-events-auto" : "pointer-events-none",
         motionEnabled && !fillsMain

--- a/desktop-workbench/renderer/src/components/theme-provider.tsx
+++ b/desktop-workbench/renderer/src/components/theme-provider.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes"
+import { WindowsTitleBar } from "@/components/desktop/windows-title-bar"
 
 function ThemeProvider({
   children,
@@ -16,6 +17,7 @@ function ThemeProvider({
       {...props}
     >
       <ThemeHotkey />
+      <WindowsTitleBar />
       {children}
     </NextThemesProvider>
   )

--- a/desktop-workbench/renderer/src/components/theme-provider.tsx
+++ b/desktop-workbench/renderer/src/components/theme-provider.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes"
-import { WindowsTitleBar } from "@/components/desktop/windows-title-bar"
+import { WindowsTitleBarProvider } from "@/components/desktop/windows-title-bar"
 
 function ThemeProvider({
   children,
@@ -17,8 +17,7 @@ function ThemeProvider({
       {...props}
     >
       <ThemeHotkey />
-      <WindowsTitleBar />
-      {children}
+      <WindowsTitleBarProvider>{children}</WindowsTitleBarProvider>
     </NextThemesProvider>
   )
 }

--- a/desktop-workbench/renderer/src/features/desktop/bridge.ts
+++ b/desktop-workbench/renderer/src/features/desktop/bridge.ts
@@ -105,6 +105,9 @@ export type DesktopServerConnection = {
 
 export type DesktopWorkbenchBridge = {
   platform: string
+  window?: {
+    setTitleBarColors: (colors: { color: string; symbolColor: string }) => Promise<void>
+  }
   versions: {
     chrome: string
     electron: string

--- a/desktop-workbench/renderer/test/windows-title-bar.test.mjs
+++ b/desktop-workbench/renderer/test/windows-title-bar.test.mjs
@@ -7,9 +7,9 @@ import ts from "typescript"
 const source = readFileSync(new URL("../src/components/desktop/windows-title-bar.tsx", import.meta.url), "utf8")
 const ast = ts.createSourceFile("windows-title-bar.tsx", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
 
-function loadFunction(name, globals) {
-  const declaration = ast.statements.find(node => ts.isFunctionDeclaration(node) && node.name?.text === name)
-  const code = ts.transpileModule(declaration.getText(ast).replace("export ", ""), {
+function loadFunction(name, globals, sourceFile = ast) {
+  const declaration = sourceFile.statements.find(node => ts.isFunctionDeclaration(node) && node.name?.text === name)
+  const code = ts.transpileModule(declaration.getText(sourceFile).replace("export ", ""), {
     compilerOptions: { target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.React },
   }).outputText
   return vm.runInNewContext(`${code}\n${name}`, globals)
@@ -70,7 +70,6 @@ test("theme synchronization waits for CSS to update and cancels stale animation 
       createElement() {},
     },
     useTheme: () => ({ resolvedTheme: "light" }),
-    appIcon: { src: "/_next/static/media/icon-mac-source.png" },
     getDesktopWorkbenchBridge: () => ({ window: { setTitleBarColors: colors => { updates.push(colors); return Promise.resolve() } } }),
     readTitleBarColors: () => ({ color: "#fafafa", symbolColor: "#0a0a0a" }),
     requestAnimationFrame: callback => { frameCallback = callback; return 7 },
@@ -85,17 +84,10 @@ test("theme synchronization waits for CSS to update and cancels stale animation 
   assert.equal(cancelled, 7)
 })
 
-test("title bar preserves the native application icon in both themes", () => {
-  const iconImport = ast.statements.find(node => ts.isImportDeclaration(node) && node.importClause?.name?.text === "appIcon")
-  assert.ok(iconImport)
-  const componentUrl = new URL("../src/components/desktop/windows-title-bar.tsx", import.meta.url)
-  const iconUrl = new URL(iconImport.moduleSpecifier.text, componentUrl)
-  assert.equal(iconUrl.href, new URL("../../build/icon-mac-source.png", import.meta.url).href)
-  assert.deepEqual(readFileSync(iconUrl).subarray(0, 8), Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
-
+test("Windows title bar exposes a controls target without an app icon or name in both themes", () => {
   for (const resolvedTheme of ["dark", "light"]) {
     const elements = []
-    const appIcon = { src: "/_next/static/media/icon-mac-source.png" }
+    const onControlsMount = () => {}
     const component = loadFunction("WindowsTitleBar", {
       React: {
         useState: () => [true, () => {}],
@@ -105,11 +97,123 @@ test("title bar preserves the native application icon in both themes", () => {
         createElement: (type, props) => { elements.push({ type, props }) },
       },
       useTheme: () => ({ resolvedTheme }),
-      appIcon,
     })
-    component()
-    const icon = elements.find(element => element.type === "img")
-    assert.equal(icon.props.src, appIcon.src)
-    assert.match(icon.props.className, /shrink-0/)
+    component({ onControlsMount })
+    const controls = elements.find(element => element.props["data-slot"] === "windows-title-bar-controls")
+    assert.equal(controls.props.ref, onControlsMount)
+    assert.ok(elements.every(element => element.type === "div"))
+  }
+})
+
+test("title bar provider shares the mounted controls target with the workspace", () => {
+  const target = {}
+  const setTarget = () => {}
+  const children = {}
+  const provider = loadFunction("WindowsTitleBarProvider", {
+    React: {
+      useState: () => [target, setTarget],
+      createElement: (type, props, ...children) => ({ type, props, children }),
+    },
+    WindowsTitleBarControlsContext: { Provider: "Provider" },
+    WindowsTitleBar: "WindowsTitleBar",
+  })
+  const rendered = provider({ children })
+  assert.equal(rendered.props.value, target)
+  assert.equal(rendered.children[0].props.onControlsMount, setTarget)
+  assert.equal(rendered.children[1], children)
+})
+
+test("docked and expanded tool sidebars start below the native title bar and still reach the bottom", () => {
+  const sidebarSource = readFileSync(new URL("../src/components/session-tool-sidebar.tsx", import.meta.url), "utf8")
+  const sidebarAst = ts.createSourceFile("session-tool-sidebar.tsx", sidebarSource, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  let classExpression
+  function visit(node) {
+    if (ts.isJsxOpeningElement(node) && node.tagName.getText(sidebarAst) === "aside") {
+      const attribute = node.attributes.properties.find(property => ts.isJsxAttribute(property) && property.name.getText(sidebarAst) === "className")
+      classExpression = attribute.initializer.expression.getText(sidebarAst)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sidebarAst)
+  assert.ok(classExpression)
+  for (const fillsMain of [false, true]) {
+    for (const motionEnabled of [false, true]) {
+      const classes = vm.runInNewContext(classExpression, {
+        cn: (...values) => values.filter(Boolean).join(" "),
+        presented: true,
+        controller: { open: true },
+        fillsMain,
+        motionEnabled,
+      }).split(" ")
+      assert.ok(classes.includes("top-[var(--aa-title-bar-height,0px)]"))
+      assert.ok(classes.includes("bottom-0"))
+      assert.ok(!classes.includes("inset-y-0"))
+      assert.ok(!classes.includes("top-0"))
+    }
+  }
+})
+
+test("navigation moves into the Windows title bar once and retains existing actions and disabled states", () => {
+  const headerSource = readFileSync(new URL("../src/components/desktop/desktop-shell-header.tsx", import.meta.url), "utf8")
+  const headerAst = ts.createSourceFile("desktop-shell-header.tsx", headerSource, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  for (const titleBarTarget of [null, {}]) {
+    for (const canGoBack of [false, true]) {
+      const elements = []
+      const portals = []
+      const calls = []
+      const component = loadFunction("DesktopShellHeader", {
+        React: {
+          useContext: () => titleBarTarget,
+          useState: () => [false, () => {}],
+          useEffect() {},
+          useCallback: callback => callback,
+          createElement: (type, props, ...children) => {
+            const element = { type, props, children }
+            elements.push(element)
+            return element
+          },
+        },
+        WindowsTitleBarControlsContext: {},
+        cn: (...values) => values.filter(Boolean).join(" "),
+        useTranslations: () => key => key,
+        useWorkspace: () => ({
+          canGoBack,
+          canGoForward: !canGoBack,
+          goBack: () => calls.push("back"),
+          goForward: () => calls.push("forward"),
+        }),
+        useDesktopConnector: () => ({ supported: false }),
+        createPortal: (children, target) => { portals.push({ children, target }); return { type: "portal" } },
+        HEADER_SIDEBAR_MIN_WIDTH: 224,
+        DashboardSidebarToggle: "SidebarToggle",
+        Button: "Button",
+        ArrowLeft: "ArrowLeft",
+        ArrowRight: "ArrowRight",
+      }, headerAst)
+      const header = component({ sidebarOpen: canGoBack, sidebarResizing: false })
+      const toggle = elements.filter(element => element.type === "SidebarToggle")
+      const buttons = elements.filter(element => element.type === "Button")
+      assert.equal(toggle.length, 1)
+      assert.equal(toggle[0].props.showOnDesktop, true)
+      assert.equal(buttons.length, 2)
+      assert.equal(buttons[0].props.disabled, !canGoBack)
+      assert.equal(buttons[1].props.disabled, canGoBack)
+      buttons[0].props.onClick()
+      buttons[1].props.onClick()
+      assert.deepEqual(calls, ["back", "forward"])
+      assert.equal(portals.length, titleBarTarget ? 1 : 0)
+      if (titleBarTarget) {
+        assert.match(header.props.className, /absolute/)
+        assert.equal(header.props.style.left, canGoBack ? "var(--desktop-sidebar-width)" : 0)
+        assert.equal(portals[0].target, titleBarTarget)
+        assert.match(portals[0].children.props.className, /aa-window-no-drag/)
+        assert.match(toggle[0].props.className, /text-sidebar-foreground/)
+        assert.ok(!elements.some(element => element.props?.className?.includes("w-[6.5rem]")))
+      } else {
+        assert.match(header.props.className, /relative/)
+        assert.equal(header.props.style, undefined)
+        assert.ok(elements.some(element => element.props?.className?.includes("w-[6.5rem]")))
+      }
+    }
   }
 })

--- a/desktop-workbench/renderer/test/windows-title-bar.test.mjs
+++ b/desktop-workbench/renderer/test/windows-title-bar.test.mjs
@@ -70,6 +70,7 @@ test("theme synchronization waits for CSS to update and cancels stale animation 
       createElement() {},
     },
     useTheme: () => ({ resolvedTheme: "light" }),
+    appIcon: { src: "/_next/static/media/icon-mac-source.png" },
     getDesktopWorkbenchBridge: () => ({ window: { setTitleBarColors: colors => { updates.push(colors); return Promise.resolve() } } }),
     readTitleBarColors: () => ({ color: "#fafafa", symbolColor: "#0a0a0a" }),
     requestAnimationFrame: callback => { frameCallback = callback; return 7 },
@@ -82,4 +83,33 @@ test("theme synchronization waits for CSS to update and cancels stale animation 
   assert.deepEqual(updates, [{ color: "#fafafa", symbolColor: "#0a0a0a" }])
   cleanup()
   assert.equal(cancelled, 7)
+})
+
+test("title bar preserves the native application icon in both themes", () => {
+  const iconImport = ast.statements.find(node => ts.isImportDeclaration(node) && node.importClause?.name?.text === "appIcon")
+  assert.ok(iconImport)
+  const componentUrl = new URL("../src/components/desktop/windows-title-bar.tsx", import.meta.url)
+  const iconUrl = new URL(iconImport.moduleSpecifier.text, componentUrl)
+  assert.equal(iconUrl.href, new URL("../../build/icon-mac-source.png", import.meta.url).href)
+  assert.deepEqual(readFileSync(iconUrl).subarray(0, 8), Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+
+  for (const resolvedTheme of ["dark", "light"]) {
+    const elements = []
+    const appIcon = { src: "/_next/static/media/icon-mac-source.png" }
+    const component = loadFunction("WindowsTitleBar", {
+      React: {
+        useState: () => [true, () => {}],
+        useRef: () => ({ current: null }),
+        useLayoutEffect() {},
+        useEffect() {},
+        createElement: (type, props) => { elements.push({ type, props }) },
+      },
+      useTheme: () => ({ resolvedTheme }),
+      appIcon,
+    })
+    component()
+    const icon = elements.find(element => element.type === "img")
+    assert.equal(icon.props.src, appIcon.src)
+    assert.match(icon.props.className, /shrink-0/)
+  }
 })

--- a/desktop-workbench/renderer/test/windows-title-bar.test.mjs
+++ b/desktop-workbench/renderer/test/windows-title-bar.test.mjs
@@ -123,36 +123,6 @@ test("title bar provider shares the mounted controls target with the workspace",
   assert.equal(rendered.children[1], children)
 })
 
-test("docked and expanded tool sidebars start below the native title bar and still reach the bottom", () => {
-  const sidebarSource = readFileSync(new URL("../src/components/session-tool-sidebar.tsx", import.meta.url), "utf8")
-  const sidebarAst = ts.createSourceFile("session-tool-sidebar.tsx", sidebarSource, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
-  let classExpression
-  function visit(node) {
-    if (ts.isJsxOpeningElement(node) && node.tagName.getText(sidebarAst) === "aside") {
-      const attribute = node.attributes.properties.find(property => ts.isJsxAttribute(property) && property.name.getText(sidebarAst) === "className")
-      classExpression = attribute.initializer.expression.getText(sidebarAst)
-    }
-    ts.forEachChild(node, visit)
-  }
-  visit(sidebarAst)
-  assert.ok(classExpression)
-  for (const fillsMain of [false, true]) {
-    for (const motionEnabled of [false, true]) {
-      const classes = vm.runInNewContext(classExpression, {
-        cn: (...values) => values.filter(Boolean).join(" "),
-        presented: true,
-        controller: { open: true },
-        fillsMain,
-        motionEnabled,
-      }).split(" ")
-      assert.ok(classes.includes("top-[var(--aa-title-bar-height,0px)]"))
-      assert.ok(classes.includes("bottom-0"))
-      assert.ok(!classes.includes("inset-y-0"))
-      assert.ok(!classes.includes("top-0"))
-    }
-  }
-})
-
 test("navigation moves into the Windows title bar once and retains existing actions and disabled states", () => {
   const headerSource = readFileSync(new URL("../src/components/desktop/desktop-shell-header.tsx", import.meta.url), "utf8")
   const headerAst = ts.createSourceFile("desktop-shell-header.tsx", headerSource, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
@@ -204,6 +174,7 @@ test("navigation moves into the Windows title bar once and retains existing acti
       assert.equal(portals.length, titleBarTarget ? 1 : 0)
       if (titleBarTarget) {
         assert.match(header.props.className, /absolute/)
+        assert.doesNotMatch(header.props.className, /\bz-\d+/)
         assert.equal(header.props.style.left, canGoBack ? "var(--desktop-sidebar-width)" : 0)
         assert.equal(portals[0].target, titleBarTarget)
         assert.match(portals[0].children.props.className, /aa-window-no-drag/)
@@ -216,4 +187,52 @@ test("navigation moves into the Windows title bar once and retains existing acti
       }
     }
   }
+})
+
+test("only Windows places the same keyed shell header after the workspace without trapping the collapse button", () => {
+  const shellSource = readFileSync(new URL("../src/components/demo.tsx", import.meta.url), "utf8")
+  const shellAst = ts.createSourceFile("demo.tsx", shellSource, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  for (const titleBarTarget of [null, {}]) {
+    const component = loadFunction("DesktopResizableShell", {
+      React: {
+        useContext: () => titleBarTarget,
+        useState: initial => [typeof initial === "function" ? initial() : initial, () => {}],
+        useRef: initial => ({ current: initial }),
+        useEffect() {},
+        useCallback: callback => callback,
+        useMemo: callback => callback(),
+        createElement: (type, props, ...children) => ({ type, props, children }),
+      },
+      useSidebar: () => ({ open: true, setOpen() {} }),
+      WindowsTitleBarControlsContext: {},
+      DashboardSidebarControlsContext: { Provider: "Provider" },
+      DEFAULT_DESKTOP_LAYOUT: { "dashboard-sidebar": 256, "dashboard-main": 1024 },
+      DESKTOP_SIDEBAR_MIN_WIDTH: 224,
+      cn: (...values) => values.filter(Boolean).join(" "),
+      DesktopShellHeader: "DesktopShellHeader",
+      ResizablePanelGroup: "ResizablePanelGroup",
+      ResizablePanel: "ResizablePanel",
+      ResizableHandle: "ResizableHandle",
+      AppSidebar: "AppSidebar",
+      SidebarInset: "SidebarInset",
+      WorkspaceMain: "WorkspaceMain",
+      SessionToolSidebarsHost: "SessionToolSidebarsHost",
+    }, shellAst)
+    const shell = component().children[0]
+    const children = shell.children.filter(Boolean)
+    assert.deepEqual(children.map(child => child.type), titleBarTarget
+      ? ["ResizablePanelGroup", "DesktopShellHeader"]
+      : ["DesktopShellHeader", "ResizablePanelGroup"])
+    assert.equal(children.find(child => child.type === "DesktopShellHeader").props.key, "desktop-shell-header")
+  }
+})
+
+test("only Windows reserves native chrome above the unchanged right sidebar", () => {
+  const css = readFileSync(new URL("../src/app/globals.css", import.meta.url), "utf8")
+  assert.match(css, /html\[data-windows-title-bar\] \[data-slot="session-tool-sidebar"\]\s*\{\s*top: var\(--aa-title-bar-height\);\s*\}/)
+  const sidebar = readFileSync(new URL("../src/components/session-tool-sidebar.tsx", import.meta.url), "utf8")
+  assert.match(sidebar, /data-slot="session-tool-sidebar"/)
+  assert.match(sidebar, /fixed inset-y-0 z-40/)
+  const sessionHeader = readFileSync(new URL("../src/components/session-view-header.tsx", import.meta.url), "utf8")
+  assert.match(sessionHeader, /relative z-50 rounded-md hover:bg-muted/)
 })

--- a/desktop-workbench/renderer/test/windows-title-bar.test.mjs
+++ b/desktop-workbench/renderer/test/windows-title-bar.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import vm from "node:vm"
+import ts from "typescript"
+
+const source = readFileSync(new URL("../src/components/desktop/windows-title-bar.tsx", import.meta.url), "utf8")
+const ast = ts.createSourceFile("windows-title-bar.tsx", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+
+function loadFunction(name, globals) {
+  const declaration = ast.statements.find(node => ts.isFunctionDeclaration(node) && node.name?.text === name)
+  const code = ts.transpileModule(declaration.getText(ast).replace("export ", ""), {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.React },
+  }).outputText
+  return vm.runInNewContext(`${code}\n${name}`, globals)
+}
+
+test("native controls receive sRGB hex colors resolved from the actual sidebar styling", () => {
+  for (const [background, foreground] of [[23, 250], [250, 10]]) {
+    const pixels = { "oklch(sidebar)": background, "oklch(sidebar-foreground)": foreground }
+    const context = {
+      clearRect() {}, fillRect() {}, fillStyle: "",
+      getImageData() { return { data: [pixels[this.fillStyle], pixels[this.fillStyle], pixels[this.fillStyle], 255] } },
+    }
+    const readColors = loadFunction("readTitleBarColors", {
+      getComputedStyle: () => ({ backgroundColor: "oklch(sidebar)", color: "oklch(sidebar-foreground)" }),
+      document: { createElement: () => ({ getContext: () => context }) },
+    })
+    const colors = readColors({})
+    assert.equal(colors.color, "#" + background.toString(16).padStart(2, "0").repeat(3))
+    assert.equal(colors.symbolColor, "#" + foreground.toString(16).padStart(2, "0").repeat(3))
+  }
+})
+
+test("title bar only reserves space on Windows and cleans up on unmount", () => {
+  for (const platform of ["win32", "darwin", "linux", null]) {
+    const dataset = {}
+    let enabled = false
+    let cleanup
+    const component = loadFunction("WindowsTitleBar", {
+      React: {
+        useState: () => [false, value => { enabled = value }],
+        useRef: () => ({ current: null }),
+        useLayoutEffect: callback => { cleanup = callback() },
+        useEffect() {},
+      },
+      useTheme: () => ({ resolvedTheme: "dark" }),
+      getDesktopWorkbenchBridge: () => platform ? { platform, window: {} } : null,
+      document: { documentElement: { dataset } },
+    })
+    assert.equal(component(), null)
+    assert.equal(enabled, platform === "win32")
+    assert.equal(dataset.windowsTitleBar, platform === "win32" ? "true" : undefined)
+    cleanup?.()
+    assert.equal(dataset.windowsTitleBar, undefined)
+  }
+})
+
+test("theme synchronization waits for CSS to update and cancels stale animation frames", () => {
+  let effect
+  let frameCallback
+  let cancelled
+  const updates = []
+  const component = loadFunction("WindowsTitleBar", {
+    React: {
+      useState: () => [true, () => {}],
+      useRef: () => ({ current: {} }),
+      useLayoutEffect() {},
+      useEffect: callback => { effect = callback },
+      createElement() {},
+    },
+    useTheme: () => ({ resolvedTheme: "light" }),
+    getDesktopWorkbenchBridge: () => ({ window: { setTitleBarColors: colors => { updates.push(colors); return Promise.resolve() } } }),
+    readTitleBarColors: () => ({ color: "#fafafa", symbolColor: "#0a0a0a" }),
+    requestAnimationFrame: callback => { frameCallback = callback; return 7 },
+    cancelAnimationFrame: frame => { cancelled = frame },
+  })
+  component()
+  const cleanup = effect()
+  assert.equal(updates.length, 0)
+  frameCallback()
+  assert.deepEqual(updates, [{ color: "#fafafa", symbolColor: "#0a0a0a" }])
+  cleanup()
+  assert.equal(cancelled, 7)
+})


### PR DESCRIPTION
## Summary
- Match the Windows title bar color to the sidebar theme.
- Move the sidebar toggle, back, and forward actions into the Windows title bar.
- Remove the Windows app branding from the title bar and login confirmation window.
- Preserve the existing right tool sidebar layout and interactions.

## Validation
- Renderer TypeScript check passes.
- Desktop main-process tests pass.
- Windows title bar regression tests pass.
- 32 independent browser layout/click cases pass across Windows/non-Windows, themes, sidebar states, and viewport sizes.