### PR TITLE
fix(connector): avoid signalling DSH processes during Windows discovery

### DIFF
--- a/connector/connector/runtimes/dsh/discovery.py
+++ b/connector/connector/runtimes/dsh/discovery.py
@@ -39,7 +39,9 @@ async def discover(values: dict[str, Any]) -> DshDiscovery:
             None,
             reason="请启动 DSH，并启用手机连接插件。",
         )
-    if not _process_exists(endpoint.pid):
+    # Windows os.kill(pid, 0) is not a process-existence probe: it uses
+    # TerminateProcess. On Windows rely on the authenticated handshake below.
+    if os.name != "nt" and not _process_exists(endpoint.pid):
         return DshDiscovery(
             False,
             False,

--- a/connector/tests/test_dsh_windows_discovery.py
+++ b/connector/tests/test_dsh_windows_discovery.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from connector.runtimes.dsh import discovery
+
+
+@pytest.mark.parametrize("valid_token", [True, False])
+def test_windows_discovery_authenticates_without_signalling_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, valid_token: bool
+) -> None:
+    kill = Mock(
+        side_effect=AssertionError("Discovery must not signal Windows processes")
+    )
+    monkeypatch.setattr(discovery, "os", SimpleNamespace(name="nt", kill=kill))
+
+    async def run() -> None:
+        methods: list[str] = []
+
+        async def handle(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            try:
+                while line := await reader.readline():
+                    request = json.loads(line)
+                    method = request["method"]
+                    methods.append(method)
+                    response = {"jsonrpc": "2.0", "id": request["id"]}
+                    if method == "initialize":
+                        if request["params"]["authToken"] != "expected-token":
+                            response["error"] = {
+                                "code": -32001,
+                                "message": "Unauthorized",
+                            }
+                        else:
+                            response["result"] = {
+                                "identity": {
+                                    "runtime": "dsh",
+                                    "protocolVersion": "1.0",
+                                    "bridgeVersion": "test",
+                                }
+                            }
+                    else:
+                        response["result"] = {}
+                    writer.write(json.dumps(response).encode() + b"\n")
+                    await writer.drain()
+            finally:
+                writer.close()
+                await writer.wait_closed()
+
+        server = await asyncio.start_server(handle, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        endpoint = tmp_path / "agents-anywhere/bridge/endpoint.json"
+        endpoint.parent.mkdir(parents=True)
+        endpoint.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "host": "127.0.0.1",
+                    "port": port,
+                    "pid": 123456,
+                    "token": "expected-token" if valid_token else "wrong-token",
+                }
+            ),
+            encoding="utf-8",
+        )
+        try:
+            result = await discovery.discover({"dshHome": str(tmp_path)})
+            assert result.available is valid_token
+            assert ("ping" in methods) is valid_token
+            kill.assert_not_called()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+        result = await discovery.discover({"dshHome": str(tmp_path)})
+        assert not result.available
+        assert result.reason
+        kill.assert_not_called()
+
+    asyncio.run(run())


### PR DESCRIPTION
DSH discovery calls `os.kill(pid, 0)` to probe the bridge process. On Windows this invokes TerminateProcess rather than a POSIX existence check: discovery can terminate DSH or fail with WinError 87, leaving the runtime without a configuration schema and absent from the addable list.

Skip the PID probe on Windows and retain the authenticated bridge initialization and ping as the availability check. POSIX keeps its existing PID check. Regression tests exercise a live loopback server, valid and invalid credentials, a closed endpoint, and assert that Windows discovery never signals the process.

Validation:
- Targeted pytest run: 16 passed, 1 skipped, 1 failed. The failure is the existing symlink canonicalization test, blocked by WinError 1314 (symlink privilege unavailable).
- New regression tests passed; Ruff check passed and the new test file was formatted.
- Restarted the local workbench Connector and triggered discovery: DSH returned present=true, available=true, a non-null schema, and no error.

Windows validation used a pre-existing local fix that moves the Codex SDK's `pwd` import into the POSIX branch. That separate startup fix is not included here and is still needed for Windows Connector startup on the current base. This PR contains only the DSH discovery change and its regression tests.
