### PR TITLE
fix(connector): import pwd only on POSIX

### DIFF
--- a/connector/connector/runtimes/codex/sdk/binary.py
+++ b/connector/connector/runtimes/codex/sdk/binary.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import pwd
 import subprocess
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -39,6 +38,8 @@ def default_login_shell() -> str | None:
         return shell
 
     if os.name == "posix":
+        import pwd
+
         try:
             return pwd.getpwuid(os.getuid()).pw_shell
         except KeyError:

--- a/connector/tests/test_codex_sdk_binary.py
+++ b/connector/tests/test_codex_sdk_binary.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_connector_cli_starts_without_unix_pwd_module() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; sys.modules['pwd'] = None; "
+                "from connector.cli import main; main(['--help'])"
+            ),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "usage:" in result.stdout


### PR DESCRIPTION
Connector startup imports the Codex SDK binary helper, which unconditionally imports the Unix-only `pwd` module. On Windows, even `anywhere-cli --help` exits with `ModuleNotFoundError: No module named pwd`, preventing the Connector from starting.

Move the import into the existing POSIX branch of `default_login_shell()`. Add a subprocess regression test that makes `pwd` unavailable and verifies the real Connector CLI can still display help.

Validation on Windows:
- `uv run pytest tests/test_codex_sdk_binary.py -q`: 1 passed.
- `uv run anywhere-cli --help`: passed.
- Ruff check for both changed files and format check for the new test: passed.

This updates Connector source; existing DSH plugin bundles need to be rebuilt and updated to include the fix.
