### PR TITLE
调整 Desktop 布局与原生玻璃侧栏

### DIFF
--- a/desktop-workbench/electron/main.ts
+++ b/desktop-workbench/electron/main.ts
@@ -7,6 +7,7 @@ import {
   Menu,
   net,
   Notification,
+  nativeTheme,
   protocol,
   session,
   shell,
@@ -33,6 +34,7 @@ import { DesktopSettingsStore } from "./desktop-settings";
 import { ConnectorLogStore } from "./log-store";
 import { readShellEnvironment } from "./shell-environment";
 import { validateTitleBarColors } from "./title-bar";
+import { windowMaterialOptions } from "./window-material";
 import config from "../config.json";
 import { proxyDesktopApi } from "./api-proxy";
 import {
@@ -297,10 +299,11 @@ function createMainWindow(showOnReady = true): BrowserWindow {
     minHeight: 680,
     show: false,
     title: APP_NAME,
+    ...windowMaterialOptions(),
     icon: appWindowIcon(),
     titleBarStyle: process.platform === "darwin" || process.platform === "win32" ? "hidden" : "default",
     titleBarOverlay: process.platform === "win32"
-      ? { color: "#171717", symbolColor: "#fafafa", height: 32 }
+      ? { color: "#00000000", symbolColor: "#fafafa", height: 32 }
       : undefined,
     trafficLightPosition: process.platform === "darwin" ? { x: 17, y: 16 } : undefined,
     webPreferences: {
@@ -512,10 +515,17 @@ function registerIpcHandlers(): void {
     assertTrustedRenderer(event);
     return requestQuit();
   });
+  ipcMain.handle("workbench:window:setTheme", (event, theme: unknown) => {
+    assertTrustedRenderer(event);
+    if (event.sender !== mainWindow?.webContents) return;
+    if (theme !== "light" && theme !== "dark") throw new Error("Invalid window theme.");
+    nativeTheme.themeSource = theme;
+  });
   ipcMain.handle("workbench:window:setTitleBarColors", (event, input: unknown) => {
     assertTrustedRenderer(event);
     if (process.platform !== "win32" || event.sender !== mainWindow?.webContents) return;
-    mainWindow.setTitleBarOverlay(validateTitleBarColors(input));
+    const colors = validateTitleBarColors(input);
+    mainWindow.setTitleBarOverlay({ ...colors, color: "#00000000" });
   });
   ipcMain.handle("workbench:updates:syncSession", (event, serverUrl: unknown) => {
     assertTrustedRenderer(event);
@@ -584,12 +594,6 @@ function registerIpcHandlers(): void {
     const result = desktopOAuthResult;
     desktopOAuthResult = null;
     return result;
-  });
-  ipcMain.handle("workbench:development:clearCache", async (event) => {
-    assertTrustedRenderer(event);
-    if (app.isPackaged) throw new Error("Cache clearing is only available in development mode.");
-    await event.sender.session.clearCache();
-    event.sender.reloadIgnoringCache();
   });
   ipcMain.handle(
     "workbench:notifications:show",

--- a/desktop-workbench/electron/preload.ts
+++ b/desktop-workbench/electron/preload.ts
@@ -1,3 +1,4 @@
+import { windowMaterial } from "./window-material";
 import type { OwnershipState } from "./local-runtime";
 import { contextBridge, ipcRenderer } from "electron";
 import type { DesktopUpdateState } from "../shared/desktop-updates";
@@ -29,7 +30,9 @@ function subscribe<T>(channel: string, callback: (value: T) => void): () => void
 
 contextBridge.exposeInMainWorld("desktopWorkbench", {
   platform: process.platform,
+  windowMaterial: windowMaterial(),
   window: {
+    setTheme: (theme: "light" | "dark"): Promise<void> => ipcRenderer.invoke("workbench:window:setTheme", theme),
     setTitleBarColors: (colors: { color: string; symbolColor: string }): Promise<void> =>
       ipcRenderer.invoke("workbench:window:setTitleBarColors", colors),
   },
@@ -61,9 +64,6 @@ contextBridge.exposeInMainWorld("desktopWorkbench", {
       ipcRenderer.invoke("workbench:auth:consumeOAuthResult"),
     onOAuthResult: (callback: () => void): (() => void) =>
       subscribe("workbench:auth:oauthResultReady", callback),
-  },
-  development: {
-    clearCache: (): Promise<void> => ipcRenderer.invoke("workbench:development:clearCache"),
   },
   notifications: {
     show: (input: DesktopNotificationInput): Promise<DesktopNotificationResult> =>

--- a/desktop-workbench/electron/window-material.test.ts
+++ b/desktop-workbench/electron/window-material.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { windowMaterial, windowMaterialOptions } from "./window-material";
+
+test("Mica is gated at Windows 11 22H2 and never makes the window frameless", () => {
+  for (const version of ["10.0.19045", "10.0.22000", "10.0.22620", "unknown"]) {
+    assert.equal(windowMaterial("win32", version), "opaque");
+    assert.equal(windowMaterialOptions("win32", version).backgroundMaterial, undefined);
+  }
+  for (const version of ["10.0.22621", "10.0.26100"]) {
+    const options = windowMaterialOptions("win32", version);
+    assert.equal(windowMaterial("win32", version), "mica");
+    assert.equal(options.backgroundMaterial, "mica");
+    assert.equal(options.backgroundColor, "#00000000");
+    assert.equal(options.transparent, undefined);
+    assert.equal(options.frame, undefined);
+  }
+});
+
+test("macOS uses native sidebar vibrancy while Linux keeps an opaque fallback", () => {
+  const mac = windowMaterialOptions("darwin", "25.0.0");
+  assert.equal(mac.vibrancy, "sidebar");
+  assert.equal(mac.transparent, true);
+  assert.equal(mac.visualEffectState, "followWindow");
+  const linux = windowMaterialOptions("linux", "6.0.0");
+  assert.equal(linux.backgroundColor, "#171717");
+  assert.equal(linux.vibrancy, undefined);
+  assert.equal(linux.backgroundMaterial, undefined);
+});

--- a/desktop-workbench/electron/window-material.ts
+++ b/desktop-workbench/electron/window-material.ts
@@ -1,0 +1,17 @@
+import { release } from "node:os";
+import type { BrowserWindowConstructorOptions } from "electron";
+
+export function windowMaterial(platform = process.platform, osRelease = release()): "transparent" | "mica" | "opaque" {
+  if (platform === "darwin") return "transparent";
+  const build = /^(?:\d+\.){2}(\d+)(?:\.|$)/.exec(osRelease)?.[1];
+  return platform === "win32" && build !== undefined && Number(build) >= 22621 ? "mica" : "opaque";
+}
+
+export function windowMaterialOptions(platform = process.platform, osRelease = release()): BrowserWindowConstructorOptions {
+  const material = windowMaterial(platform, osRelease);
+  if (material === "transparent") {
+    return { transparent: true, backgroundColor: "#00000000", vibrancy: "sidebar", visualEffectState: "followWindow" };
+  }
+  if (material === "mica") return { backgroundColor: "#00000000", backgroundMaterial: "mica" };
+  return { backgroundColor: "#171717" };
+}

--- a/desktop-workbench/renderer/src/app/globals.css
+++ b/desktop-workbench/renderer/src/app/globals.css
@@ -189,6 +189,85 @@ body {
   -webkit-app-region: drag;
 }
 
+/* The native compositor supplies the sidebar glass. Keep content surfaces opaque. */
+html[data-window-material="transparent"],
+html[data-window-material="mica"],
+html:is([data-window-material="transparent"], [data-window-material="mica"]) body {
+  background: transparent;
+}
+
+html:is([data-window-material="transparent"], [data-window-material="mica"]) [data-slot="sidebar-wrapper"],
+html:is([data-window-material="transparent"], [data-window-material="mica"]) .aa-desktop-sidebar [data-slot="sidebar-inner"],
+html:is([data-window-material="transparent"], [data-window-material="mica"]) .aa-windows-title-bar {
+  background: transparent;
+}
+
+.aa-desktop-sidebar {
+  padding-top: 44px;
+  background: var(--sidebar);
+}
+
+html:is([data-window-material="transparent"], [data-window-material="mica"]) .aa-desktop-sidebar {
+  background: transparent;
+  --sidebar-accent: color-mix(in oklch, var(--sidebar-foreground) 10%, transparent);
+}
+
+.aa-desktop-main {
+  border-left: 1px solid var(--sidebar-border);
+}
+
+.aa-desktop-drag-region {
+  display: none;
+}
+
+/* macOS has no native title bar. Reserve a borderless drag area above page
+ * controls; session pages already provide their own draggable header. */
+html[data-desktop-platform="darwin"] .aa-desktop-main:not([data-page="session"]) {
+  padding-top: 28px;
+}
+
+html[data-desktop-platform="darwin"] .aa-desktop-main:not([data-page="session"]) .aa-desktop-drag-region {
+  display: block;
+  position: absolute;
+  inset: 0 12px auto 0;
+  height: 28px;
+  -webkit-app-region: drag;
+}
+
+html[data-windows-title-bar] .aa-desktop-main {
+  border-top: 1px solid var(--sidebar-border);
+  border-top-left-radius: 12px;
+}
+
+.aa-desktop-shell[data-sidebar-open="false"] .aa-desktop-main {
+  padding-top: 44px;
+}
+
+html[data-desktop-platform="darwin"] .aa-desktop-shell[data-sidebar-open="false"] .aa-desktop-main {
+  padding-top: 44px;
+}
+
+html[data-desktop-platform="darwin"] .aa-desktop-shell[data-sidebar-open="false"] .aa-desktop-drag-region {
+  display: block;
+  position: absolute;
+  inset: 0 12px auto 224px;
+  height: 44px;
+  -webkit-app-region: drag;
+}
+
+html[data-windows-title-bar] .aa-desktop-sidebar,
+html[data-windows-title-bar] .aa-desktop-shell[data-sidebar-open="false"] .aa-desktop-main {
+  padding-top: 0;
+}
+
+html[data-desktop-platform="linux"] .aa-traffic-light-spacer {
+  width: 12px;
+}
+
+html:not([data-windows-title-bar]):has(.aa-desktop-shell[data-sidebar-open="false"]) [data-slot="session-tool-sidebar"] {
+  top: 44px;
+}
+
 html[data-windows-title-bar] {
   --aa-title-bar-height: 32px;
 }

--- a/desktop-workbench/renderer/src/app/globals.css
+++ b/desktop-workbench/renderer/src/app/globals.css
@@ -212,6 +212,12 @@ html:is([data-window-material="transparent"], [data-window-material="mica"]) .aa
   --sidebar-accent: color-mix(in oklch, var(--sidebar-foreground) 10%, transparent);
 }
 
+/* Keep a neutral scrim over macOS vibrancy so wallpaper colors do not wash
+ * out sidebar labels. The sidebar token also follows the light theme. */
+html[data-desktop-platform="darwin"][data-window-material="transparent"] .aa-desktop-sidebar {
+  background: color-mix(in oklch, var(--sidebar) 65%, transparent);
+}
+
 .aa-desktop-main {
   border-left: 1px solid var(--sidebar-border);
 }

--- a/desktop-workbench/renderer/src/components/app-sidebar.tsx
+++ b/desktop-workbench/renderer/src/components/app-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { DesktopConnectionStatus } from "@/components/desktop/desktop-shell-header"
 import { Plus, Smartphone } from "lucide-react"
 import { toast } from "sonner"
 
@@ -238,6 +239,7 @@ export function AppSidebar({ contained = false }: { contained?: boolean }) {
             </SidebarMenuItem>
           ) : null}
         </SidebarMenu>
+        <DesktopConnectionStatus />
       </SidebarHeader>
 
       <SidebarContent className="px-2">

--- a/desktop-workbench/renderer/src/components/demo.tsx
+++ b/desktop-workbench/renderer/src/components/demo.tsx
@@ -7,7 +7,6 @@ import { SidebarProvider, SidebarInset, useSidebar } from "@/components/ui/sideb
 import { DashboardSidebarControlsContext } from "@/components/dashboard-sidebar-controls"
 import { AppSidebar } from "@/components/app-sidebar"
 import { DesktopShellHeader } from "@/components/desktop/desktop-shell-header"
-import { WindowsTitleBarControlsContext } from "@/components/desktop/windows-title-bar"
 import { DesktopSessionNotifications } from "@/components/desktop/desktop-session-notifications"
 import { TaskComposer } from "@/components/task-composer"
 import { SessionView } from "@/components/session-view"
@@ -41,7 +40,6 @@ import {
 } from "@/components/ui/resizable"
 import { useTranslations } from "next-intl"
 import { DesktopConnectorProvider } from "@/features/desktop/desktop-connector-context"
-import { cn } from "@/lib/utils"
 
 const SIDEBAR_LAYOUT_STORAGE_KEY = "agents-anywhere-dashboard-sidebar-layout"
 const DEFAULT_DESKTOP_LAYOUT = {
@@ -85,7 +83,7 @@ function DashboardShell() {
 
 function DesktopResizableShell() {
   const { open, setOpen } = useSidebar()
-  const titleBarControls = React.useContext(WindowsTitleBarControlsContext)
+  const { page } = useWorkspace()
   const desktopShellRef = React.useRef<HTMLDivElement | null>(null)
   const sidebarPanelRef = React.useRef<PanelImperativeHandle | null>(null)
   const sidebarMotionActiveRef = React.useRef(false)
@@ -193,12 +191,12 @@ function DesktopResizableShell() {
     <DashboardSidebarControlsContext.Provider value={sidebarControls}>
       <div
         ref={desktopShellRef}
-        className={cn("flex h-svh min-h-0 w-full flex-col overflow-hidden overscroll-none bg-background", titleBarControls && "relative")}
+        data-sidebar-open={open}
+        className="aa-desktop-shell relative flex h-svh min-h-0 w-full flex-col overflow-hidden overscroll-none"
         style={{
           "--desktop-sidebar-width": `${Math.max(sidebarWidth, DESKTOP_SIDEBAR_MIN_WIDTH)}px`,
         } as React.CSSProperties}
       >
-        {titleBarControls ? null : shellHeader}
         <ResizablePanelGroup
           id="agents-anywhere-dashboard-sidebar"
           defaultLayout={defaultLayout}
@@ -208,7 +206,7 @@ function DesktopResizableShell() {
             }
           }}
           direction="horizontal"
-          className={`min-h-0 flex-1 overflow-hidden overscroll-none bg-background ${panelMotionClassName}`}
+          className={`min-h-0 flex-1 overflow-hidden overscroll-none ${panelMotionClassName}`}
         >
           <ResizablePanel
             id="dashboard-sidebar"
@@ -236,7 +234,7 @@ function DesktopResizableShell() {
             style={{ overflow: "hidden" }}
           >
             <div
-              className="h-full shrink-0 overflow-hidden"
+              className="aa-desktop-sidebar h-full shrink-0 overflow-hidden"
               style={{ width: Math.max(sidebarWidth, DESKTOP_SIDEBAR_MIN_WIDTH) }}
             >
               <AppSidebar contained />
@@ -258,12 +256,21 @@ function DesktopResizableShell() {
             onLostPointerCapture={() => setSidebarResizeActive(false)}
           />
           <ResizablePanel id="dashboard-main" minSize={0} className="min-w-0">
-            <SidebarInset className={cn("h-full min-h-0 overflow-hidden overscroll-none bg-background", titleBarControls && "pt-11")}>
-              <WorkspaceMain />
+            <SidebarInset data-page={page} className="aa-desktop-main h-full min-h-0 overflow-hidden overscroll-none bg-background">
+              <div className="aa-desktop-drag-region" aria-hidden="true" />
+              {page === "session" ? (
+                <header className="aa-window-drag flex h-11 shrink-0 items-center gap-2 px-3">
+                  <div data-slot="desktop-shell-header-session" className="flex min-w-0 flex-1 items-center overflow-hidden" />
+                  <div data-slot="desktop-shell-header-session-actions" className="aa-window-no-drag flex shrink-0 items-center" />
+                </header>
+              ) : null}
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                <WorkspaceMain />
+              </div>
             </SidebarInset>
           </ResizablePanel>
         </ResizablePanelGroup>
-        {titleBarControls ? shellHeader : null}
+        {shellHeader}
       </div>
       <SessionToolSidebarsHost />
     </DashboardSidebarControlsContext.Provider>

--- a/desktop-workbench/renderer/src/components/desktop/desktop-shell-header.tsx
+++ b/desktop-workbench/renderer/src/components/desktop/desktop-shell-header.tsx
@@ -2,16 +2,14 @@
 
 import * as React from "react"
 import { createPortal } from "react-dom"
-import { ArrowLeft, ArrowRight, Eraser, Info } from "lucide-react"
+import { ArrowLeft, ArrowRight, Info } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { toast } from "sonner"
 
 import { DashboardSidebarToggle } from "@/components/dashboard-sidebar-toggle"
 import { WindowsTitleBarControlsContext } from "@/components/desktop/windows-title-bar"
 import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
 import { useWorkspace } from "@/components/workspace-context"
-import { getDesktopWorkbenchBridge } from "@/features/desktop/bridge"
 import { useDesktopConnector } from "@/features/desktop/desktop-connector-context"
 import { cn } from "@/lib/utils"
 
@@ -24,45 +22,10 @@ export function DesktopShellHeader({
   sidebarOpen: boolean
   sidebarResizing: boolean
 }) {
-  const t = useTranslations("desktopConnector")
   const tCommon = useTranslations("common")
   const { canGoBack, canGoForward, goBack, goForward } = useWorkspace()
   const titleBarControls = React.useContext(WindowsTitleBarControlsContext)
-  const { supported, busy, state, binding, reconnect } = useDesktopConnector()
-  const [canClearCache, setCanClearCache] = React.useState(false)
-  const [clearingCache, setClearingCache] = React.useState(false)
-  const localConnectorId = binding?.connectorId ?? state?.connectorId
-  const needsReconnect = Boolean(
-    supported &&
-    localConnectorId &&
-    (state?.authFailed || state?.manualDisconnected),
-  )
-  const headerSidebarWidth = sidebarOpen
-    ? "var(--desktop-sidebar-width)"
-    : HEADER_SIDEBAR_MIN_WIDTH
-  const sidebarWidthMotionClassName = sidebarResizing
-    ? "transition-none"
-    : "transition-[width] duration-[220ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
-  const shellControlClassName = sidebarOpen || titleBarControls
-    ? "rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-    : "rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-
-  React.useEffect(() => {
-    if (process.env.NODE_ENV !== "development") return
-    setCanClearCache(Boolean(getDesktopWorkbenchBridge()?.development?.clearCache))
-  }, [])
-
-  const clearCache = React.useCallback(async () => {
-    const clear = getDesktopWorkbenchBridge()?.development?.clearCache
-    if (!clear) return
-    setClearingCache(true)
-    try {
-      await clear()
-    } catch (error) {
-      setClearingCache(false)
-      toast.error(error instanceof Error ? error.message : t("clearCacheFailed"))
-    }
-  }, [t])
+  const shellControlClassName = "rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
 
   const navigationControls = (
     <div className="aa-window-no-drag flex min-w-0 items-center gap-2">
@@ -99,91 +62,39 @@ export function DesktopShellHeader({
     </div>
   )
 
+  if (titleBarControls) return createPortal(navigationControls, titleBarControls)
+
   return (
     <header
       data-slot="desktop-shell-header"
       className={cn(
-        "aa-window-drag flex h-11 shrink-0 items-center bg-background text-foreground",
-        titleBarControls ? "absolute top-0 right-0" : "relative",
+        "aa-desktop-navigation aa-window-drag absolute left-0 top-0 flex h-11 items-center text-sidebar-foreground",
+        sidebarResizing ? "transition-none" : "transition-[width] duration-[220ms] motion-reduce:transition-none",
       )}
-      style={titleBarControls ? { left: sidebarOpen ? "var(--desktop-sidebar-width)" : 0 } : undefined}
+      style={{ width: sidebarOpen ? "var(--desktop-sidebar-width)" : HEADER_SIDEBAR_MIN_WIDTH }}
     >
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-border/80"
-      />
-      <div
-        aria-hidden="true"
-        className={`pointer-events-none absolute inset-y-0 left-0 bg-sidebar ${sidebarWidthMotionClassName}`}
-        style={{ width: sidebarOpen && !titleBarControls ? "var(--desktop-sidebar-width)" : 0 }}
-      />
-      <div
-        className={sidebarOpen
-          ? `relative flex h-full shrink-0 items-center text-sidebar-foreground ${sidebarWidthMotionClassName}`
-          : `relative flex h-full shrink-0 items-center text-foreground ${sidebarWidthMotionClassName}`
-        }
-        style={{ width: titleBarControls ? 0 : headerSidebarWidth }}
-      >
-        {titleBarControls ? createPortal(navigationControls, titleBarControls) : (
-          <>
-            <div className="w-[6.5rem] shrink-0" aria-hidden="true" />
-            {navigationControls}
-          </>
-        )}
-      </div>
-      <div
-        data-slot="desktop-shell-header-session"
-        className="ml-2 flex min-w-0 flex-1 items-center overflow-hidden"
-      />
-      {needsReconnect ? (
-        <div className="aa-window-no-drag absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-2">
-          <span className="flex items-center gap-1.5 text-xs font-medium text-foreground" role="status" aria-live="polite">
-            <Info className="size-3.5 text-destructive" aria-hidden="true" />
-            {t("localOffline")}
-          </span>
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            onClick={() => void reconnect()}
-            disabled={busy}
-          >
-            {busy ? <Spinner data-icon="inline-start" /> : null}
-            {busy ? t("reconnecting") : t("reconnect")}
-          </Button>
-        </div>
-      ) : null}
-      <div
-        data-slot="desktop-shell-header-actions"
-        className="ml-auto flex h-full shrink-0 items-center justify-end gap-1 px-3"
-      >
-        {canClearCache ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => void clearCache()}
-            disabled={clearingCache}
-            aria-label={t("clearCache")}
-            title={t("clearCache")}
-            className="aa-window-no-drag rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            {clearingCache ? <Spinner data-icon="inline-start" /> : <Eraser data-icon="inline-start" />}
-            {clearingCache ? t("clearingCache") : t("clearCache")}
-          </Button>
-        ) : null}
-        <div
-          data-slot="desktop-shell-header-session-actions"
-          className="aa-window-no-drag flex shrink-0 items-center"
-        />
-      </div>
-      {!sidebarOpen && !titleBarControls ? (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute top-1/2 h-5 w-px -translate-y-1/2 bg-border/60"
-          style={{ left: headerSidebarWidth }}
-        />
-      ) : null}
+      <div className="aa-traffic-light-spacer w-[6.5rem] shrink-0" aria-hidden="true" />
+      {navigationControls}
     </header>
+  )
+}
+
+export function DesktopConnectionStatus() {
+  const t = useTranslations("desktopConnector")
+  const { supported, busy, state, binding, reconnect } = useDesktopConnector()
+  const localConnectorId = binding?.connectorId ?? state?.connectorId
+  if (!supported || !localConnectorId || !(state?.authFailed || state?.manualDisconnected)) return null
+
+  return (
+    <div className="aa-window-no-drag flex flex-wrap items-center gap-2 px-1 pt-2">
+      <span className="flex items-center gap-1.5 text-xs" role="status" aria-live="polite">
+        <Info className="size-3.5 text-destructive" aria-hidden="true" />
+        {t("localOffline")}
+      </span>
+      <Button type="button" variant="outline" size="xs" onClick={() => void reconnect()} disabled={busy}>
+        {busy ? <Spinner data-icon="inline-start" /> : null}
+        {busy ? t("reconnecting") : t("reconnect")}
+      </Button>
+    </div>
   )
 }

--- a/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
+++ b/desktop-workbench/renderer/src/components/desktop/windows-title-bar.tsx
@@ -12,6 +12,7 @@ export function WindowsTitleBarProvider({ children }: { children: React.ReactNod
 
   return (
     <WindowsTitleBarControlsContext.Provider value={controlsTarget}>
+      <NativeWindowMaterial />
       <WindowsTitleBar onControlsMount={setControlsTarget} />
       {children}
     </WindowsTitleBarControlsContext.Provider>
@@ -79,4 +80,24 @@ export function WindowsTitleBar({
       />
     </div>
   )
+}
+
+function NativeWindowMaterial() {
+  const { resolvedTheme } = useTheme()
+  React.useLayoutEffect(() => {
+    const bridge = getDesktopWorkbenchBridge()
+    if (!bridge) return
+    const root = document.documentElement
+    root.dataset.desktopPlatform = bridge.platform
+    root.dataset.windowMaterial = bridge.windowMaterial ?? "opaque"
+    return () => {
+      delete root.dataset.desktopPlatform
+      delete root.dataset.windowMaterial
+    }
+  }, [])
+  React.useEffect(() => {
+    if (resolvedTheme !== "light" && resolvedTheme !== "dark") return
+    void getDesktopWorkbenchBridge()?.window?.setTheme?.(resolvedTheme).catch(console.error)
+  }, [resolvedTheme])
+  return null
 }

--- a/desktop-workbench/renderer/src/features/desktop/bridge.ts
+++ b/desktop-workbench/renderer/src/features/desktop/bridge.ts
@@ -109,6 +109,7 @@ export type DesktopServerConnection = {
 
 export type DesktopWorkbenchBridge = {
   platform: string
+  windowMaterial?: "transparent" | "mica" | "opaque"
   ownership?: {
     getState: () => Promise<LocalOwnershipState>
     recheck: () => Promise<LocalOwnershipState>
@@ -116,6 +117,7 @@ export type DesktopWorkbenchBridge = {
     onState: (listener: (state: LocalOwnershipState) => void) => () => void
   }
   window?: {
+    setTheme?: (theme: "light" | "dark") => Promise<void>
     setTitleBarColors: (colors: { color: string; symbolColor: string }) => Promise<void>
   }
   versions: {
@@ -144,9 +146,6 @@ export type DesktopWorkbenchBridge = {
       | null
     >
     onOAuthResult: (listener: () => void) => void | (() => void)
-  }
-  development?: {
-    clearCache: () => Promise<void>
   }
   notifications?: {
     show: (input: {

--- a/desktop-workbench/renderer/test/windows-title-bar.test.mjs
+++ b/desktop-workbench/renderer/test/windows-title-bar.test.mjs
@@ -116,11 +116,12 @@ test("title bar provider shares the mounted controls target with the workspace",
     },
     WindowsTitleBarControlsContext: { Provider: "Provider" },
     WindowsTitleBar: "WindowsTitleBar",
+    NativeWindowMaterial: "NativeWindowMaterial",
   })
   const rendered = provider({ children })
   assert.equal(rendered.props.value, target)
-  assert.equal(rendered.children[0].props.onControlsMount, setTarget)
-  assert.equal(rendered.children[1], children)
+  assert.equal(rendered.children[1].props.onControlsMount, setTarget)
+  assert.equal(rendered.children[2], children)
 })
 
 test("navigation moves into the Windows title bar once and retains existing actions and disabled states", () => {
@@ -173,23 +174,21 @@ test("navigation moves into the Windows title bar once and retains existing acti
       assert.deepEqual(calls, ["back", "forward"])
       assert.equal(portals.length, titleBarTarget ? 1 : 0)
       if (titleBarTarget) {
-        assert.match(header.props.className, /absolute/)
-        assert.doesNotMatch(header.props.className, /\bz-\d+/)
-        assert.equal(header.props.style.left, canGoBack ? "var(--desktop-sidebar-width)" : 0)
+        assert.equal(header.type, "portal")
         assert.equal(portals[0].target, titleBarTarget)
         assert.match(portals[0].children.props.className, /aa-window-no-drag/)
         assert.match(toggle[0].props.className, /text-sidebar-foreground/)
         assert.ok(!elements.some(element => element.props?.className?.includes("w-[6.5rem]")))
       } else {
-        assert.match(header.props.className, /relative/)
-        assert.equal(header.props.style, undefined)
+        assert.match(header.props.className, /absolute/)
+        assert.equal(header.props.style.width, canGoBack ? "var(--desktop-sidebar-width)" : 224)
         assert.ok(elements.some(element => element.props?.className?.includes("w-[6.5rem]")))
       }
     }
   }
 })
 
-test("only Windows places the same keyed shell header after the workspace without trapping the collapse button", () => {
+test("navigation stays outside the content panels and session chrome is scoped to session pages", () => {
   const shellSource = readFileSync(new URL("../src/components/demo.tsx", import.meta.url), "utf8")
   const shellAst = ts.createSourceFile("demo.tsx", shellSource, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
   for (const titleBarTarget of [null, {}]) {
@@ -204,6 +203,7 @@ test("only Windows places the same keyed shell header after the workspace withou
         createElement: (type, props, ...children) => ({ type, props, children }),
       },
       useSidebar: () => ({ open: true, setOpen() {} }),
+      useWorkspace: () => ({ page: "device" }),
       WindowsTitleBarControlsContext: {},
       DashboardSidebarControlsContext: { Provider: "Provider" },
       DEFAULT_DESKTOP_LAYOUT: { "dashboard-sidebar": 256, "dashboard-main": 1024 },
@@ -220,9 +220,7 @@ test("only Windows places the same keyed shell header after the workspace withou
     }, shellAst)
     const shell = component().children[0]
     const children = shell.children.filter(Boolean)
-    assert.deepEqual(children.map(child => child.type), titleBarTarget
-      ? ["ResizablePanelGroup", "DesktopShellHeader"]
-      : ["DesktopShellHeader", "ResizablePanelGroup"])
+    assert.deepEqual(children.map(child => child.type), ["ResizablePanelGroup", "DesktopShellHeader"])
     assert.equal(children.find(child => child.type === "DesktopShellHeader").props.key, "desktop-shell-header")
   }
 })


### PR DESCRIPTION
移除 Desktop 右侧的全局顶部空栏和清理缓存入口，将会话标题与工具操作保留在会话页面。macOS 侧栏使用原生 vibrancy，并叠加 65% 的主题灰色底以保持文字可读；Windows 11 22H2 及以上使用 Mica，较旧版本保持普通背景。

同时修复内容容器的垂直居中，补充 macOS 透明拖动区域和侧栏收起后的窗口按钮避让，并同步原生窗口与页面的明暗主题。

验证：
- 主进程及 renderer 类型检查通过。
- 主进程 87 项、renderer 205 项测试通过（后续布局与灰色底样式微调前）。
- 最终改动通过 git diff --check；原生材质观感与交互由用户手动验收。
