### PR TITLE
fix(desktop): 修复 Windows 关闭窗口后托盘后台运行

### DIFF
--- a/desktop-workbench/README.md
+++ b/desktop-workbench/README.md
@@ -5,6 +5,11 @@ Connector in one Electron application. The renderer remains the control
 console; Electron Main owns the Connector CLI process and communicates with it
 over stdio JSON-RPC. No localhost management server is opened.
 
+On Windows, closing the window hides it to the system tray and keeps the local
+Connector running. Click the tray icon or choose **打开 Agents Anywhere** to
+reopen the window. Choose **退出** from the tray menu to confirm exit and stop
+the local Connector; cancelling keeps the app running.
+
 ```text
 Renderer -> narrow preload IPC -> Electron Main -> anywhere-cli rpc -> Server
 ```

--- a/desktop-workbench/electron/main-lifecycle.test.ts
+++ b/desktop-workbench/electron/main-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -29,6 +30,7 @@ function quitFixture(options: { confirm?: boolean; shutdown?: () => Promise<void
     isQuitting: false,
     shutdownComplete: false,
     shutdownPromise: null,
+    tray: null as { destroy: () => void } | null,
     confirmQuit: async () => { calls.push("confirm"); return options.confirm ?? true; },
     mainWindow: options.window === false ? null : {
       isDestroyed: () => false,
@@ -76,6 +78,129 @@ test("quit still completes if the window is already gone or local shutdown fails
   await assert.rejects(fixture.requestQuit(), /already stopped/);
   assert.deepEqual(fixture.calls, ["stop-updates", "stop-local-connector", "quit"]);
   assert.equal(fixture.globals.shutdownComplete, true);
+});
+
+test("Windows close hides the window without confirming quit, and reopening restores it", () => {
+  const calls: string[] = [];
+  class Window extends EventEmitter {
+    webContents = Object.assign(new EventEmitter(), { setWindowOpenHandler: () => {} });
+    loadURL = async () => {};
+    hide = () => calls.push("hide");
+    isDestroyed = () => false;
+    isMinimized = () => true;
+    restore = () => calls.push("restore");
+    show = () => calls.push("show");
+    moveTop = () => {};
+    focus = () => calls.push("focus");
+  }
+  const globals = {
+    process: { platform: "win32", env: {} },
+    app: { isPackaged: true },
+    BrowserWindow: Window,
+    APP_NAME: "Agents Anywhere",
+    path,
+    __dirname,
+    mainWindow: null,
+    devOrigin: null,
+    isQuitting: false,
+    windowMaterialOptions: () => ({}),
+    appWindowIcon: () => "icon.png",
+    staticWorkbenchUrl: () => "aa-workbench://web/",
+    showDockForWindow: () => {},
+    requestQuit: () => assert.fail("Closing the Windows window must not request quit"),
+  };
+  const { createMainWindow, showMainWindow } = loadFunctions(["createMainWindow", "showMainWindow"], globals);
+  const window = createMainWindow(false) as Window;
+  window.emit("ready-to-show");
+  assert.equal(calls.length, 0, "silent launch leaves the window hidden");
+  window.emit("close", { preventDefault: () => calls.push("prevent-close") });
+  assert.deepEqual(calls, ["prevent-close", "hide"]);
+  showMainWindow();
+  assert.deepEqual(calls.slice(2), ["restore", "show", "focus"]);
+  calls.length = 0;
+  globals.isQuitting = true;
+  window.emit("close", { preventDefault: () => assert.fail("Confirmed quit must allow closing") });
+  showMainWindow();
+  assert.deepEqual(calls, [], "shutdown must not reopen the window");
+});
+
+test("Windows tray opens the app, cancels exit, and shuts down only after confirmation", async () => {
+  for (const packaged of [false, true]) {
+    let confirm = false;
+    const fixture = quitFixture();
+    const appPath = path.resolve(__dirname, "../..");
+    const resourcesPath = path.join(appPath, "test-resources");
+    type TrayItem = { label?: string; click?: () => void };
+    class TestTray extends EventEmitter {
+      menu: TrayItem[] = [];
+      constructor(readonly icon: string) { super(); }
+      setToolTip = (name: string) => assert.equal(name, "Agents Anywhere");
+      setContextMenu = (menu: TrayItem[]) => { this.menu = menu; };
+      destroy = () => fixture.calls.push("destroy-tray");
+    }
+    const globals = Object.assign(fixture.globals, {
+      tray: null as TestTray | null,
+      process: { platform: "win32", resourcesPath },
+      app: { ...fixture.globals.app, isPackaged: packaged, getAppPath: () => appPath },
+      path,
+      APP_NAME: "Agents Anywhere",
+      Tray: TestTray,
+      Menu: { buildFromTemplate: (items: TrayItem[]) => items },
+      showMainWindow: () => fixture.calls.push("show"),
+      confirmQuit: async () => { fixture.calls.push("confirm"); return confirm; },
+      requestQuit: fixture.requestQuit,
+    });
+    const { createWindowsTray } = loadFunctions(["createWindowsTray"], globals);
+    createWindowsTray();
+    const tray = globals.tray!;
+    assert.equal(tray.icon, path.join(packaged ? resourcesPath : appPath, "build", "icon.ico"));
+    createWindowsTray();
+    assert.equal(globals.tray, tray, "initialization must retain a single tray instance");
+    tray.emit("click");
+    tray.menu.find((item) => item.label === "打开 Agents Anywhere")!.click!();
+    assert.deepEqual(fixture.calls, ["show", "show"]);
+    fixture.calls.length = 0;
+    const exit = tray.menu.find((item) => item.label === "退出")!.click!;
+    exit();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(fixture.calls, ["confirm"]);
+    assert.equal(globals.tray, tray);
+    assert.equal(globals.isQuitting, false);
+    confirm = true;
+    exit();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(fixture.calls, ["confirm", "confirm", "stop-updates", "destroy-tray", "destroy-renderer", "stop-local-connector", "quit"]);
+    assert.equal(globals.tray, null);
+  }
+});
+
+test("tray quit confirmation stays accessible when the main window is hidden or destroyed", async () => {
+  for (const state of ["visible", "hidden", "destroyed", "absent"]) {
+    const window = state === "absent" ? null : {
+      isDestroyed: () => state === "destroyed",
+      isVisible: () => state === "visible",
+    };
+    const { confirmQuit } = loadFunctions(["confirmQuit"], {
+      quitConfirmationPromise: null,
+      mainWindow: window,
+      dialog: { showMessageBox: async (...args: unknown[]) => {
+        assert.equal(args.length, state === "visible" ? 2 : 1);
+        if (state === "visible") assert.equal(args[0], window);
+        return { response: 0 };
+      } },
+    });
+    assert.equal(await confirmQuit(), false);
+  }
+});
+
+test("the Windows tray ICO is included in packaged resources", () => {
+  const root = path.resolve(__dirname, "../..");
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+  const resource = manifest.build.extraResources.find((item: { to: string }) => item.to === "build/icon.ico");
+  assert.ok(resource, "the tray icon must be available outside app.asar");
+  const icon = fs.readFileSync(path.join(root, resource.from));
+  assert.equal(icon.readUInt16LE(2), 1, "the bundled asset must be an ICO");
+  assert.ok(icon.readUInt16LE(4) > 0, "the ICO must contain images");
 });
 
 test("project API requests reach the Desktop proxy even with an empty API namespace", () => {

--- a/desktop-workbench/electron/main.ts
+++ b/desktop-workbench/electron/main.ts
@@ -11,6 +11,7 @@ import {
   protocol,
   session,
   shell,
+  Tray,
   type IpcMainInvokeEvent,
 } from "electron";
 import fs from "node:fs";
@@ -83,6 +84,7 @@ let ownership: OwnershipState = { status: "error", message: "正在检查本机 
 let recheckingOwnership: Promise<OwnershipState> | null = null;
 
 let mainWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
 let devOrigin: string | null = null;
 let settingsStore: DesktopSettingsStore | null = null;
 let bindingStore: DesktopBindingStore | null = null;
@@ -351,7 +353,7 @@ function createMainWindow(showOnReady = true): BrowserWindow {
   window.on("close", (event) => {
     if (isQuitting) return;
     event.preventDefault();
-    if (process.platform === "darwin") {
+    if (process.platform === "darwin" || process.platform === "win32") {
       window.hide();
       return;
     }
@@ -365,6 +367,7 @@ function createMainWindow(showOnReady = true): BrowserWindow {
 }
 
 function showMainWindow(): void {
+  if (isQuitting) return;
   const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : createMainWindow(false);
   showDockForWindow();
   if (window.isMinimized()) window.restore();
@@ -372,6 +375,19 @@ function showMainWindow(): void {
   window.moveTop();
   if (process.platform === "darwin") app.focus({ steal: true });
   window.focus();
+}
+
+function createWindowsTray(): void {
+  if (process.platform !== "win32" || tray) return;
+  const iconPath = path.join(app.isPackaged ? process.resourcesPath : app.getAppPath(), "build", "icon.ico");
+  tray = new Tray(iconPath);
+  tray.setToolTip(APP_NAME);
+  tray.setContextMenu(Menu.buildFromTemplate([
+    { label: "打开 Agents Anywhere", click: () => showMainWindow() },
+    { type: "separator" },
+    { label: "退出", click: () => { void requestQuit({ confirm: true }); } },
+  ]));
+  tray.on("click", () => showMainWindow());
 }
 
 function hideDockIfIdle(): void {
@@ -843,7 +859,8 @@ async function confirmQuit(): Promise<boolean> {
       cancelId: 0,
       noLink: true,
     };
-    const result = mainWindow
+    // A hidden window must not own the tray's confirmation dialog.
+    const result = mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()
       ? await dialog.showMessageBox(mainWindow, options)
       : await dialog.showMessageBox(options);
     return result.response === 1;
@@ -865,6 +882,8 @@ async function requestQuit({ confirm = false }: { confirm?: boolean } = {}): Pro
   shutdownPromise = (async () => {
     try {
       updates?.dispose();
+      tray?.destroy();
+      tray = null;
       quiesceRendererForShutdown();
       await connector?.shutdown();
     } finally {
@@ -915,6 +934,7 @@ if (hasSingleInstanceLock) {
     });
     const settings = requireSettings().get();
     const showOnLaunch = ownership.status !== "owned" || !settings.silentLaunch || !launchedAsLoginItem() || Boolean(process.env.WORKBENCH_WEB_URL);
+    createWindowsTray();
     createMainWindow(showOnLaunch);
     if (app.isPackaged && ownership.status === "owned") await drainDesktopOAuthCallbacks();
     if (process.platform === "darwin" && app.dock) app.dock.setIcon(appWindowIcon());

--- a/desktop-workbench/package.json
+++ b/desktop-workbench/package.json
@@ -68,6 +68,10 @@
         "to": "build/icon-mac-source.png"
       },
       {
+        "from": "build/icon.ico",
+        "to": "build/icon.ico"
+      },
+      {
         "from": "build/uv",
         "to": "uv",
         "filter": [


### PR DESCRIPTION
Windows 点击窗口右上角关闭按钮时，原先会直接弹出退出确认并伴随系统提示音，而且新版桌面没有初始化托盘。现在关闭窗口会隐藏到系统托盘，保持本机 Connector 后台运行。

- 添加 Windows 托盘图标和“打开 Agents Anywhere / 退出”菜单，并将 ICO 资源纳入打包。
- 点击托盘图标或“打开”恢复窗口；选择“退出”才进入退出确认流程，取消后继续运行。
- 窗口隐藏时使用无父窗口的退出确认框；确认退出后清理托盘和 Connector，并防止关闭过程中重新打开窗口。

验证：`corepack yarn test:main` 通过，包含 TypeScript 编译和全部 91 项主进程测试；`git diff --check` 通过。新增测试覆盖关闭隐藏、托盘恢复、取消及确认退出、隐藏窗口弹窗和 ICO 打包资源。当前在 macOS 环境验证，Windows 实机托盘显示与系统音效仍需验收。
