### PR TITLE
test(dsh-bridge-next): 覆盖陈旧 endpoint 的 PID 复用恢复

### DIFF
--- a/dsh-bridge-next/VERIFICATION.md
+++ b/dsh-bridge-next/VERIFICATION.md
@@ -1,5 +1,15 @@
 # DSH Bridge Next 验证记录
 
+## 陈旧 endpoint 的 pid 复用误判（2026-09-12）
+
+Windows 实机报告「本机连接被占用，无法启动」。`<DSH_HOME>/agents-anywhere/bridge/endpoint.json` 残留了当天 15:03 首次启动写入的记录（`pid 7444`），该 pid 随后被系统复用为无关系统进程；`processExists()` 只执行 `process.kill(pid, 0)`，因此每次重试都在 `RuntimeServer.open` 抛 `Another DSH bridge owns this DSH_HOME endpoint`（`BRIDGE_IN_USE`），只有手工删除该文件后重启才恢复。删除后 18:45 重新发布端点，Connector 随后接入并完成 10 个会话的首次同步。
+
+管理租约（由 endpoint 目录 realpath 推导的确定性回环端口）才是归属权威：活着的桥接会持有该端口，因此能进入 `open()` 就已证明本路径没有活着的桥接，文件里记录的 pid 不构成证据。现已移除该存活门并始终接管陈旧发布；`dispose()` 仍按 token 与 pid 匹配后才删除端点。
+
+新增回归用例：以另一个存活但无关的进程 pid 伪造陈旧 endpoint，断言桥接仍能启动、端点被替换且可完成 RPC。该用例在未修改的 `b4133309` 上以与实机相同的错误失败，修复后通过。
+
+插件全量 133 项、通过 112 项（含新增 1 项）；未修改的 main 为 132 项、通过 111 项，两边失败集合完全相同（21 项，均为 Windows 本地的 `ERR_INVALID_URL_SCHEME` 等既有环境问题，CI 在 ubuntu 上运行）。类型检查的三处错误（TS2344、两处 TS2717）在未修改的 `b4133309` 上同样复现，与本改动无关。
+
 ## 桥接日志页与实机定位（2026-09-08）
 
 插件新增「手机连接 → 桥接日志」：固定读取本插件两份运行日志，最近 200 条，每两秒刷新，可暂停；不依赖 Connector 所有权、账号或安装检测成功。DSH 日志分类与文件均记录错误码、读取阶段、会话 ID 和去除异常正文后的堆栈，Python 同时记录插件发出的 `runtime.error`。

--- a/dsh-bridge-next/src/host/dsh-runtime/server.ts
+++ b/dsh-bridge-next/src/host/dsh-runtime/server.ts
@@ -16,11 +16,6 @@ async function endpointAt(path: string): Promise<Record<string, unknown> | undef
   catch (error) { if (record(error).code === 'ENOENT') return undefined; throw error }
 }
 
-function processExists(pid: unknown): boolean {
-  if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid < 1) return false
-  try { process.kill(pid, 0); return true } catch (error) { return record(error).code !== 'ESRCH' }
-}
-
 /** Private loopback transport. Discovery probes can coexist with a Connector connection. */
 export class RuntimeServer {
   private server: Server | undefined
@@ -74,10 +69,12 @@ export class RuntimeServer {
     try {
       await mkdir(dirname(this.endpointPath), { recursive: true, mode: 0o700 })
       const existing = await endpointAt(this.endpointPath)
-      if (existing) {
-        if (processExists(existing.pid)) throw new Error('Another DSH bridge owns this DSH_HOME endpoint')
-        await unlink(this.endpointPath)
-      }
+      // The manager lease is the ownership authority. A live bridge holds the
+      // directory-derived lease port, so reaching this point already proves no
+      // live bridge owns this path. A recorded pid is not evidence either way:
+      // the OS can hand a crashed bridge's pid to an unrelated process, which
+      // used to block startup until the stale file was deleted by hand.
+      if (existing) await unlink(this.endpointPath)
       // Link publishes a complete file atomically and refuses to overwrite a competing owner.
       const temporary = `${this.endpointPath}.${token}.tmp`
       try {

--- a/dsh-bridge-next/tests/integration/runtime.test.ts
+++ b/dsh-bridge-next/tests/integration/runtime.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { execFile } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 import { promisify } from 'node:util'
-import { access, appendFile, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { access, appendFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createConnection } from 'node:net'
 import { createInterface } from 'node:readline'
@@ -116,4 +116,28 @@ test('concurrent starts cannot overwrite ownership and closing twice releases th
     assert.equal((await recovered.rpc('ping')).result.ok, true)
     recovered.socket.destroy()
   } finally { await Promise.allSettled(servers.map(server => server.close())); await rm(home, { recursive: true, force: true }) }
+})
+
+test('a stale endpoint whose pid was reused by another live process is taken over', { timeout: 15_000 }, async () => {
+  const home = await mkdtemp(join(tmpdir(), 'aa-dsh-reused-pid-'))
+  const path = join(home, 'bridge/endpoint.json')
+  const reader = { query: { listSessions: async () => [], readTitleSnapshots: async () => [], readSession: async () => { throw new Error('unused') } }, status: () => undefined }
+  // A crashed bridge leaves its publication behind; the OS later reuses that pid
+  // for an unrelated process, which must not look like a live bridge owner.
+  const unrelated = spawn(process.execPath, ['--eval', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' })
+  const server = new RuntimeServer(path, reader)
+  try {
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, JSON.stringify({ version: 1, host: '127.0.0.1', port: 1, token: 'crashed-owner', pid: unrelated.pid }))
+    const value = await server.start()
+    assert.notEqual(value.token, 'crashed-owner')
+    assert.equal(JSON.parse(await readFile(path, 'utf8')).token, value.token)
+    const connection = await client(value)
+    assert.equal((await connection.rpc('ping')).result.ok, true)
+    connection.socket.destroy()
+  } finally {
+    await server.close()
+    unrelated.kill('SIGKILL')
+    await rm(home, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
DSH 异常退出后留下的 endpoint 可能记录了已被无关进程复用的 PID，旧实现会持续误报 `BRIDGE_IN_USE`。当前 main 已使用 OS 管理租约判定归属，并清理陈旧或损坏的 endpoint；本 PR 与 main 合并后保留该实现，新增独立存活进程 PID 的回归覆盖和验证记录。

新增测试以一个真实的无关存活进程构造旧 endpoint，确认桥接能重新发布端点并完成认证 RPC。贡献者最初定位的 Windows 问题和验证记录保留在 `dsh-bridge-next/VERIFICATION.md`。

验证：

- macOS 本地重新构建插件成功。
- `runtime.test.ts` 与 `runtime-ownership.test.ts` 共 8 项全部通过，包含真实 Python adapter、错误凭据、并发独占、崩溃恢复和 PID 复用。
- `tsc -p tsconfig.host.json` 通过。
- 本轮没有重新执行 Windows 实机验证；GitHub CI 状态以本 PR 的检查结果为准。
